### PR TITLE
feat: Stripe payments - card on file, online payment, refunds, webhoo…

### DIFF
--- a/API-Layer/Controllers/BookingController.cs
+++ b/API-Layer/Controllers/BookingController.cs
@@ -2,8 +2,10 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Authorization;
 using MediatR;
 using Application_Layer.Commands.BookingCommands.CreateBooking;
+using Application_Layer.Commands.BookingCommands.ReconcilePaidBooking;
 using Application_Layer.Commands.BookingCommands.UpdateBooking;
 using Application_Layer.Commands.BookingCommands.CancelBooking;
+using Application_Layer.Commands.BookingCommands.MarkBookingNoShow;
 using Application_Layer.Commands.BookingCommands.AssignEmployee;
 using Application_Layer.Queries.BookingQueries.GetBookingById;
 using Application_Layer.Queries.BookingQueries.GetAvailableTimeSlots;
@@ -65,6 +67,20 @@ namespace API_Layer.Controllers
             return HandleResult(result);
         }
 
+        /// <summary>
+        /// Slutför en bokning efter en genomförd onlinebetalning (redirect-retur, t.ex. Klarna).
+        /// Bokningsuppgifterna hämtas serverside ur PaymentIntent-metadatan; idempotent.
+        /// </summary>
+        [HttpPost("from-payment")]
+        public async Task<ActionResult<BookingDTO>> CreateFromPayment([FromBody] FinalizePaymentDTO body)
+        {
+            if (!TryGetCurrentUserId(out var userId)) return Unauthorized();
+
+            // userId skickas med så avstämningen kan verifiera att betalningen tillhör anroparen.
+            var result = await _mediator.Send(new ReconcilePaidBookingCommand(body.PaymentIntentId, userId));
+            return HandleResult(result);
+        }
+
         [HttpGet("{id}")]
         public async Task<ActionResult<BookingDTO>> GetBookingById(Guid id)
         {
@@ -103,6 +119,15 @@ namespace API_Layer.Controllers
             var command = new CancelBookingCommand(id, userId, User.IsInRole("Employee"));
             var result = await _mediator.Send(command);
             return HandleResult(result);
+        }
+
+        /// <summary>Markera en passerad bokning som utebliven → drar no-show-avgift från sparat kort.</summary>
+        [HttpPost("{id}/no-show")]
+        [Authorize(Roles = "Admin,Employee")]
+        public async Task<IActionResult> MarkNoShow(Guid id, CancellationToken ct)
+        {
+            var result = await _mediator.Send(new MarkBookingNoShowCommand(id), ct);
+            return HandleResult(result, () => Ok(new { message = "Bokningen har markerats som utebliven." }));
         }
 
         [HttpGet("availability")]

--- a/API-Layer/Controllers/PaymentController.cs
+++ b/API-Layer/Controllers/PaymentController.cs
@@ -1,0 +1,48 @@
+using Application_Layer.Commands.PaymentCommands.CreatePaymentIntent;
+using Application_Layer.Commands.PaymentCommands.CreateSetupIntent;
+using Application_Layer.DTOs;
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace API_Layer.Controllers;
+
+[Route("api/payments")]
+[ApiController]
+[Authorize]
+public class PaymentController : BaseApiController
+{
+    private readonly IMediator _mediator;
+
+    public PaymentController(IMediator mediator)
+    {
+        _mediator = mediator;
+    }
+
+    /// <summary>
+    /// Skapar en Stripe SetupIntent så att den inloggade kunden kan spara ett kort (0 kr dras).
+    /// Frontend använder clientSecret för att bekräfta kortet via Stripe.js.
+    /// </summary>
+    [HttpPost("setup-intent")]
+    public async Task<IActionResult> CreateSetupIntent(CancellationToken ct)
+    {
+        if (!TryGetCurrentUserId(out var userId)) return Unauthorized();
+
+        var result = await _mediator.Send(new CreateSetupIntentCommand(userId), ct);
+        return HandleResult(result);
+    }
+
+    /// <summary>
+    /// Skapar en PaymentIntent för onlinebetalning vid bokning (hela priset).
+    /// Frontend bekräftar betalningen med clientSecret via Stripe.js.
+    /// </summary>
+    [HttpPost("payment-intent")]
+    public async Task<IActionResult> CreatePaymentIntent([FromBody] PaymentIntentRequestDTO body, CancellationToken ct)
+    {
+        if (!TryGetCurrentUserId(out var userId)) return Unauthorized();
+
+        var result = await _mediator.Send(
+            new CreatePaymentIntentCommand(userId, body.ServiceId, body.EmployeeId, body.StartTime, body.EndTime), ct);
+        return HandleResult(result);
+    }
+}

--- a/API-Layer/Controllers/StripeWebhookController.cs
+++ b/API-Layer/Controllers/StripeWebhookController.cs
@@ -1,0 +1,80 @@
+using Application_Layer.Commands.BookingCommands.ReconcilePaidBooking;
+using Application_Layer.Interfaces;
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace API_Layer.Controllers;
+
+/// <summary>
+/// Tar emot Stripe-webhooks. Anonym (Stripe autentiserar via signatur, inte JWT) och
+/// läser rå body för signaturverifiering — därför en egen controller utanför [Authorize].
+/// Orphan-skydd: vid payment_intent.succeeded stäms betalningen av mot en bokning, så
+/// en kund som betalar via redirect (Klarna) men aldrig kommer tillbaka ändå får sin
+/// bokning (eller en automatisk återbetalning om tiden hunnit tas).
+/// </summary>
+[Route("api/stripe")]
+[ApiController]
+[AllowAnonymous]
+public class StripeWebhookController : ControllerBase
+{
+    private readonly IStripePaymentService _stripe;
+    private readonly IMediator _mediator;
+    private readonly ILogger<StripeWebhookController> _logger;
+
+    public StripeWebhookController(
+        IStripePaymentService stripe, IMediator mediator, ILogger<StripeWebhookController> logger)
+    {
+        _stripe = stripe;
+        _mediator = mediator;
+        _logger = logger;
+    }
+
+    [HttpPost("webhook")]
+    public async Task<IActionResult> Handle()
+    {
+        using var reader = new StreamReader(Request.Body);
+        var json = await reader.ReadToEndAsync();
+        var signature = Request.Headers["Stripe-Signature"].ToString();
+
+        var result = _stripe.ParseWebhook(json, signature);
+        if (result == null)
+        {
+            // Ogiltig signatur (eller Stripe ej konfigurerat) → avvisa.
+            return BadRequest();
+        }
+
+        switch (result.Type)
+        {
+            case "payment_intent.succeeded" when !string.IsNullOrWhiteSpace(result.PaymentIntentId):
+                // Säkerställ att betalningen har en bokning. Idempotent: om /payment-return
+                // redan skapat den svarar avstämningen "redan kopplad" (Conflict) och vi
+                // struntar i det. Saknas bokningen skapas den nu (eller auto-återbetalas
+                // om tiden tagits).
+                // RequestingUserId=null: webhooken agerar som systemet — Stripe-signaturen
+                // är auktoriseringen och PI-metadatan avgör vem bokningen tillhör.
+                var reconcile = await _mediator.Send(new ReconcilePaidBookingCommand(result.PaymentIntentId!, null));
+                if (reconcile.Successful)
+                {
+                    _logger.LogInformation(
+                        "Webhook skapade bokning för betalning {PaymentIntentId}", result.PaymentIntentId);
+                }
+                else
+                {
+                    _logger.LogInformation(
+                        "Webhook-avstämning för {PaymentIntentId}: {Reason}",
+                        result.PaymentIntentId, reconcile.Error);
+                }
+                break;
+            case "payment_intent.payment_failed":
+                _logger.LogWarning("Stripe payment failed for payment {PaymentIntentId}", result.PaymentIntentId);
+                break;
+            default:
+                _logger.LogInformation("Received Stripe event {EventType}", result.Type);
+                break;
+        }
+
+        // Kvittera alltid 200 för verifierade events så Stripe inte gör om leveransen.
+        return Ok();
+    }
+}

--- a/API-Layer/appsettings.example.json
+++ b/API-Layer/appsettings.example.json
@@ -52,5 +52,12 @@
   "GoogleAuth": {
     "ClientId": "YOUR_GOOGLE_CLIENT_ID.apps.googleusercontent.com"
   },
+  "Stripe": {
+    "SecretKey": "sk_test_YOUR_STRIPE_SECRET_KEY",
+    "PublishableKey": "pk_test_YOUR_STRIPE_PUBLISHABLE_KEY",
+    "WebhookSecret": "whsec_YOUR_STRIPE_WEBHOOK_SIGNING_SECRET",
+    "NoShowFeeAmount": 200,
+    "Currency": "sek"
+  },
   "AllowedHosts": "*"
 }

--- a/Application-Layer/Commands/BookingCommands/CancelBooking/CancelBookingCommandHandler.cs
+++ b/Application-Layer/Commands/BookingCommands/CancelBooking/CancelBookingCommandHandler.cs
@@ -12,18 +12,21 @@ namespace Application_Layer.Commands.BookingCommands.CancelBooking
         private readonly IServiceRepository _serviceRepository;
         private readonly IMediator _mediator;
         private readonly INotificationService _notificationService;
+        private readonly IStripePaymentService _stripe;
 
         public CancelBookingCommandHandler(
             IBookingRepository bookingRepository,
             IServiceRepository serviceRepository,
             IMediator mediator,
-            INotificationService notificationService
+            INotificationService notificationService,
+            IStripePaymentService stripe
         )
         {
             _bookingRepository = bookingRepository;
             _serviceRepository = serviceRepository;
             _mediator = mediator;
             _notificationService = notificationService;
+            _stripe = stripe;
         }
 
         public async Task<OperationResult> Handle(CancelBookingCommand request, CancellationToken cancellationToken)
@@ -48,6 +51,31 @@ namespace Application_Layer.Commands.BookingCommands.CancelBooking
                 return OperationResult.Failure("Cannot cancel a booking that has already started or completed.");
             }
 
+            // Återbetalning: om kunden betalat online återbetalas hela beloppet vid
+            // avbokning i god tid (>24h före). Senare än så behålls pengarna som
+            // sen-avboknings-avgift (samma gräns som no-show, enligt villkoren).
+            var refunded = false;
+            var paidOnline = !string.IsNullOrWhiteSpace(booking.StripePaymentIntentId)
+                && booking.PaymentStatus == PaymentStatus.PaidInFull;
+            if (_stripe.IsConfigured && paidOnline)
+            {
+                var hoursUntilStart = (booking.StartTime - SwedishTime.Now).TotalHours;
+                if (hoursUntilStart > 24)
+                {
+                    var refund = await _stripe.RefundAsync(
+                        booking.StripePaymentIntentId!, amountMinorUnit: null,
+                        idempotencyKey: $"refund-{booking.Id}", cancellationToken);
+                    if (!refund.Succeeded)
+                    {
+                        // Blockera avbokningen om återbetalningen inte gick — undvik att
+                        // bokningen försvinner medan kundens pengar är kvar. Låt kunden försöka igen.
+                        return OperationResult.Failure(refund.Error ?? "Återbetalningen misslyckades. Försök igen.");
+                    }
+                    booking.PaymentStatus = PaymentStatus.Refunded;
+                    refunded = true;
+                }
+            }
+
             // Soft delete: behåll bokningen men markera den som avbokad, så att
             // avbokningen kan följas upp i adminrapporten. Operativa queries
             // (mina bokningar, personalens schema, konfliktkontroll) filtrerar
@@ -59,8 +87,11 @@ namespace Application_Layer.Commands.BookingCommands.CancelBooking
             var serviceName = service != null ? service.Name : "tjänsten";
 
             var title = "Bokning avbokad";
+            var refundNote = refunded
+                ? " Ditt inbetalda belopp återbetalas."
+                : paidOnline ? " Enligt villkoren återbetalas inte beloppet vid avbokning senare än 24 timmar före besöket." : "";
             var message = $"Din bokning för {serviceName} " +
-                          $"({booking.StartTime:yyyy-MM-dd HH:mm}) har avbokats.";
+                          $"({booking.StartTime:yyyy-MM-dd HH:mm}) har avbokats.{refundNote}";
 
             var notificationCmd = new CreateNotificationCommand
             {

--- a/Application-Layer/Commands/BookingCommands/CreateBooking/CreateBookingCommandHandler.cs
+++ b/Application-Layer/Commands/BookingCommands/CreateBooking/CreateBookingCommandHandler.cs
@@ -1,5 +1,6 @@
 using MediatR;
 using Application_Layer.Mapping;
+using Application_Layer.Common;
 using Domain_Layer.Common;
 using Domain_Layer.Models;
 using Application_Layer.Interfaces;
@@ -17,6 +18,7 @@ namespace Application_Layer.Commands.BookingCommands.CreateBooking
         private readonly INotificationService _notificationService;
         private readonly IConversationRepository _conversationRepository;
         private readonly IUserRepository _userRepository;
+        private readonly IStripePaymentService _stripePaymentService;
 
         public CreateBookingCommandHandler(
             IBookingRepository bookingRepository,
@@ -25,7 +27,8 @@ namespace Application_Layer.Commands.BookingCommands.CreateBooking
             IMediator mediator,
             INotificationService notificationService,
             IConversationRepository conversationRepository,
-            IUserRepository userRepository
+            IUserRepository userRepository,
+            IStripePaymentService stripePaymentService
         )
         {
             _bookingRepository = bookingRepository;
@@ -35,6 +38,7 @@ namespace Application_Layer.Commands.BookingCommands.CreateBooking
             _notificationService = notificationService;
             _conversationRepository = conversationRepository;
             _userRepository = userRepository;
+            _stripePaymentService = stripePaymentService;
         }
 
         public async Task<OperationResult<BookingModel>> Handle(CreateBookingCommand request, CancellationToken cancellationToken)
@@ -48,9 +52,70 @@ namespace Application_Layer.Commands.BookingCommands.CreateBooking
                     return OperationResult<BookingModel>.Failure("Service not found.");
                 }
 
+                // Betalning: när Stripe är konfigurerat krävs antingen en online-betalning
+                // (PaymentIntent) ELLER ett sparat kort (kort-på-fil, betala på plats).
+                // Utan Stripe (lokal dev) bokas kortlöst.
+                var paymentMethodId = request.Booking.PaymentMethodId;
+                var paymentIntentId = request.Booking.PaymentIntentId;
+                if (_stripePaymentService.IsConfigured
+                    && string.IsNullOrWhiteSpace(paymentMethodId)
+                    && string.IsNullOrWhiteSpace(paymentIntentId))
+                {
+                    return OperationResult<BookingModel>.Failure("Betalning eller sparat kort krävs för att boka.");
+                }
+
                 // 2) Skapa & spara bokning
                 var booking = _mapper.ToBookingModel(request.Booking);
                 booking.Id = Guid.NewGuid();
+
+                if (!string.IsNullOrWhiteSpace(paymentIntentId))
+                {
+                    // Samma betalning får inte användas till flera bokningar (t.ex. om
+                    // Klarna-returflödet råkar köras om efter att bokningen redan skapats).
+                    if (await _bookingRepository.ExistsByPaymentIntentIdAsync(paymentIntentId))
+                    {
+                        return OperationResult<BookingModel>.Failure(
+                            "Betalningen är redan kopplad till en bokning.", OperationFailureType.Conflict);
+                    }
+
+                    // Onlinebetalning: verifiera serverside att den faktiskt gått igenom och
+                    // att beloppet matchar (klienten får aldrig bestämma beloppet).
+                    var info = await _stripePaymentService.GetPaymentIntentAsync(paymentIntentId, cancellationToken);
+                    if (info == null || info.Status != "succeeded")
+                    {
+                        return OperationResult<BookingModel>.Failure("Betalningen kunde inte verifieras.");
+                    }
+                    if (info.Refunded)
+                    {
+                        // T.ex. en konflikt-återbetald betalning vars webhook levereras om.
+                        return OperationResult<BookingModel>.Failure("Betalningen är återbetald och kan inte användas.");
+                    }
+
+                    var expectedKr = service.Price;
+                    if (info.AmountReceivedMinorUnit != PaymentAmounts.ToMinorUnit(expectedKr))
+                    {
+                        // Priset hann ändras mellan betalning och bokning → behåll aldrig
+                        // pengar utan bokning; återbetala automatiskt.
+                        var mismatchRefund = await _stripePaymentService.RefundAsync(
+                            paymentIntentId, amountMinorUnit: null,
+                            idempotencyKey: $"amount-mismatch-refund-{paymentIntentId}", cancellationToken);
+                        return OperationResult<BookingModel>.Failure(mismatchRefund.Succeeded
+                            ? "Betalt belopp stämmer inte med behandlingens pris. Din betalning återbetalas automatiskt."
+                            : "Betalt belopp stämmer inte med behandlingens pris och återbetalningen kunde inte genomföras — kontakta kliniken.");
+                    }
+
+                    booking.StripePaymentIntentId = paymentIntentId;
+                    booking.AmountPaid = expectedKr;
+                    booking.PaymentStatus = PaymentStatus.PaidInFull;
+                }
+                else if (!string.IsNullOrWhiteSpace(paymentMethodId))
+                {
+                    // Betala på plats: koppla det sparade kortet (no-show debiteras detta).
+                    booking.StripePaymentMethodId = paymentMethodId;
+                    var card = await _stripePaymentService.GetCardDetailsAsync(paymentMethodId, cancellationToken);
+                    booking.CardBrand = card?.Brand;
+                    booking.CardLast4 = card?.Last4;
+                }
                 // Assign employee only if provided; chat activates first when employee exists
                 var employeeId = request.Booking.EmployeeId;
                 booking.EmployeeId = employeeId;
@@ -82,6 +147,28 @@ namespace Application_Layer.Commands.BookingCommands.CreateBooking
                 var added = await _bookingRepository.TryAddIfNoConflictAsync(booking);
                 if (!added)
                 {
+                    // Kunden har redan betalat online men tiden hann tas (t.ex. under en
+                    // Klarna-redirect) → återbetala automatiskt så inga pengar fastnar.
+                    if (booking.PaymentStatus == PaymentStatus.PaidInFull
+                        && !string.IsNullOrWhiteSpace(booking.StripePaymentIntentId))
+                    {
+                        // Race-skydd: om returflödet och webhooken tävlade om SAMMA betalning
+                        // har vinnaren redan skapat bokningen — då är detta ingen konflikt
+                        // att återbetala (det hade gett kunden både bokning och pengar).
+                        if (await _bookingRepository.ExistsByPaymentIntentIdAsync(booking.StripePaymentIntentId))
+                        {
+                            return OperationResult<BookingModel>.Failure(
+                                "Betalningen är redan kopplad till en bokning.", OperationFailureType.Conflict);
+                        }
+
+                        var refund = await _stripePaymentService.RefundAsync(
+                            booking.StripePaymentIntentId, amountMinorUnit: null,
+                            idempotencyKey: $"conflict-refund-{booking.StripePaymentIntentId}", cancellationToken);
+                        return OperationResult<BookingModel>.Failure(refund.Succeeded
+                            ? "Den valda tiden är inte längre tillgänglig. Din betalning återbetalas automatiskt."
+                            : "Den valda tiden är inte längre tillgänglig och återbetalningen kunde inte genomföras automatiskt — kontakta kliniken.");
+                    }
+
                     return OperationResult<BookingModel>.Failure("Den valda tiden är inte längre tillgänglig. Välj en annan tid.");
                 }
 
@@ -111,6 +198,16 @@ namespace Application_Layer.Commands.BookingCommands.CreateBooking
             }
             catch (Exception ex)
             {
+                // Race-förloraren när två avstämningar (retur + webhook) tävlar om samma
+                // betalning stoppas av det unika indexet på StripePaymentIntentId →
+                // svara "redan kopplad" istället för ett generiskt fel. Ingen refund:
+                // pengarna hör till vinnarens bokning.
+                if (!string.IsNullOrWhiteSpace(request.Booking.PaymentIntentId)
+                    && await _bookingRepository.ExistsByPaymentIntentIdAsync(request.Booking.PaymentIntentId))
+                {
+                    return OperationResult<BookingModel>.Failure(
+                        "Betalningen är redan kopplad till en bokning.", OperationFailureType.Conflict);
+                }
                 return OperationResult<BookingModel>.Failure($"Failed to create booking: {ex.Message}");
             }
         }

--- a/Application-Layer/Commands/BookingCommands/MarkBookingNoShow/MarkBookingNoShowCommand.cs
+++ b/Application-Layer/Commands/BookingCommands/MarkBookingNoShow/MarkBookingNoShowCommand.cs
@@ -1,0 +1,11 @@
+using Domain_Layer.Common;
+using MediatR;
+
+namespace Application_Layer.Commands.BookingCommands.MarkBookingNoShow
+{
+    /// <summary>
+    /// Personal markerar en passerad bokning som utebliven → drar no-show-avgiften
+    /// off-session från kundens sparade kort och sätter status NoShow.
+    /// </summary>
+    public sealed record MarkBookingNoShowCommand(Guid BookingId) : IRequest<OperationResult>;
+}

--- a/Application-Layer/Commands/BookingCommands/MarkBookingNoShow/MarkBookingNoShowCommandHandler.cs
+++ b/Application-Layer/Commands/BookingCommands/MarkBookingNoShow/MarkBookingNoShowCommandHandler.cs
@@ -1,0 +1,122 @@
+using Application_Layer.Commands.NotificationCommands.CreateNotification;
+using Application_Layer.Common;
+using Application_Layer.Interfaces;
+using Domain_Layer.Common;
+using Domain_Layer.Models;
+using MediatR;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace Application_Layer.Commands.BookingCommands.MarkBookingNoShow
+{
+    public class MarkBookingNoShowCommandHandler : IRequestHandler<MarkBookingNoShowCommand, OperationResult>
+    {
+        private readonly IBookingRepository _bookingRepository;
+        private readonly IUserRepository _userRepository;
+        private readonly IServiceRepository _serviceRepository;
+        private readonly IStripePaymentService _stripe;
+        private readonly IMediator _mediator;
+        private readonly INotificationService _notificationService;
+        private readonly IConfiguration _configuration;
+        private readonly ILogger<MarkBookingNoShowCommandHandler> _logger;
+
+        public MarkBookingNoShowCommandHandler(
+            IBookingRepository bookingRepository,
+            IUserRepository userRepository,
+            IServiceRepository serviceRepository,
+            IStripePaymentService stripe,
+            IMediator mediator,
+            INotificationService notificationService,
+            IConfiguration configuration,
+            ILogger<MarkBookingNoShowCommandHandler> logger)
+        {
+            _bookingRepository = bookingRepository;
+            _userRepository = userRepository;
+            _serviceRepository = serviceRepository;
+            _stripe = stripe;
+            _mediator = mediator;
+            _notificationService = notificationService;
+            _configuration = configuration;
+            _logger = logger;
+        }
+
+        public async Task<OperationResult> Handle(MarkBookingNoShowCommand request, CancellationToken cancellationToken)
+        {
+            // GetByIdAsync returnerar bara Active-bokningar, så en redan avbokad/no-show-markerad
+            // bokning hittas inte → idempotent (kan inte dubbelmarkeras/dubbeldebiteras).
+            var booking = await _bookingRepository.GetByIdAsync(request.BookingId);
+            if (booking == null)
+            {
+                return OperationResult.Failure(
+                    $"Booking with ID {request.BookingId} was not found or is not active.",
+                    OperationFailureType.NotFound);
+            }
+
+            if (booking.StartTime > SwedishTime.Now)
+            {
+                return OperationResult.Failure("Kan inte markera en framtida bokning som utebliven.");
+            }
+
+            // Förbetald bokning (hela beloppet online): pengarna finns redan → ingen
+            // kortdebitering, bara markera utebliven (det inbetalda behålls som straff).
+            var prepaid = booking.PaymentStatus == PaymentStatus.PaidInFull;
+
+            // Debitera no-show-avgift när Stripe är konfigurerat och bokningen INTE är förbetald.
+            // Måste lyckas innan bokningen markeras — annars stannar den kvar så personalen kan försöka igen.
+            if (_stripe.IsConfigured && !prepaid)
+            {
+                var user = await _userRepository.FindByIdAsync(booking.UserId);
+                if (user == null || string.IsNullOrWhiteSpace(user.StripeCustomerId)
+                    || string.IsNullOrWhiteSpace(booking.StripePaymentMethodId))
+                {
+                    return OperationResult.Failure(
+                        "Bokningen saknar sparat kort och kan inte debiteras automatiskt.");
+                }
+
+                var feeKr = _configuration.GetValue<decimal>("Stripe:NoShowFeeAmount", 200m);
+                var currency = _configuration["Stripe:Currency"] ?? "sek";
+                var amountMinor = PaymentAmounts.ToMinorUnit(feeKr);
+
+                var charge = await _stripe.ChargeOffSessionAsync(
+                    user.StripeCustomerId, booking.StripePaymentMethodId, amountMinor, currency,
+                    $"No-show fee for booking {booking.Id}",
+                    new Dictionary<string, string> { ["bookingId"] = booking.Id.ToString() },
+                    idempotencyKey: $"noshow-{booking.Id}",
+                    cancellationToken);
+
+                if (!charge.Succeeded)
+                {
+                    _logger.LogWarning("No-show charge failed for booking {BookingId}: {Error}",
+                        booking.Id, charge.Error);
+                    return OperationResult.Failure(charge.Error ?? "No-show-avgiften kunde inte dras.");
+                }
+
+                booking.NoShowFeeChargedAt = SwedishTime.Now;
+            }
+
+            booking.Status = BookingStatus.NoShow;
+            await _bookingRepository.UpdateAsync(booking);
+
+            var service = await _serviceRepository.GetServiceByIdAsync(booking.ServiceId);
+            var serviceName = service?.Name ?? "din behandling";
+            var title = "Utebliven bokning";
+            var message = booking.NoShowFeeChargedAt.HasValue
+                ? $"Du uteblev från din bokning för {serviceName} ({booking.StartTime:yyyy-MM-dd HH:mm}). En avgift har dragits från ditt sparade kort."
+                : $"Din bokning för {serviceName} ({booking.StartTime:yyyy-MM-dd HH:mm}) har markerats som utebliven.";
+
+            await _mediator.Send(new CreateNotificationCommand
+            {
+                Title = title,
+                Message = message,
+                UserId = booking.UserId,
+                Type = NotificationType.NoShowFeeCharged,
+                BookingId = booking.Id,
+            }, cancellationToken);
+
+            await _notificationService.SendBookingNotificationAsync(
+                booking.UserId, title, message, NotificationType.NoShowFeeCharged, booking.Id);
+
+            return OperationResult.Success();
+        }
+    }
+}

--- a/Application-Layer/Commands/BookingCommands/ReconcilePaidBooking/ReconcilePaidBookingCommand.cs
+++ b/Application-Layer/Commands/BookingCommands/ReconcilePaidBooking/ReconcilePaidBookingCommand.cs
@@ -1,0 +1,17 @@
+using Domain_Layer.Common;
+using Domain_Layer.Models;
+using MediatR;
+
+namespace Application_Layer.Commands.BookingCommands.ReconcilePaidBooking
+{
+    /// <summary>
+    /// Skapar bokningen för en redan genomförd onlinebetalning, utifrån bokningsuppgifterna
+    /// i PaymentIntent-metadatan. Anropas av /payment-return (kunden kom tillbaka) OCH av
+    /// Stripe-webhooken (orphan-skydd om kunden aldrig kom tillbaka). Idempotent — samma
+    /// betalning ger bara en bokning.
+    /// RequestingUserId = inloggad användare (måste äga betalningen); null = webhooken
+    /// (Stripe-signaturen är auktoriseringen, metadatan avgör ägaren).
+    /// </summary>
+    public sealed record ReconcilePaidBookingCommand(string PaymentIntentId, string? RequestingUserId)
+        : IRequest<OperationResult<BookingModel>>;
+}

--- a/Application-Layer/Commands/BookingCommands/ReconcilePaidBooking/ReconcilePaidBookingCommandHandler.cs
+++ b/Application-Layer/Commands/BookingCommands/ReconcilePaidBooking/ReconcilePaidBookingCommandHandler.cs
@@ -1,0 +1,132 @@
+using System.Globalization;
+using Application_Layer.Commands.BookingCommands.CreateBooking;
+using Application_Layer.DTOs;
+using Application_Layer.Interfaces;
+using Domain_Layer.Common;
+using Domain_Layer.Models;
+using FluentValidation;
+using MediatR;
+using Microsoft.Extensions.Logging;
+
+namespace Application_Layer.Commands.BookingCommands.ReconcilePaidBooking
+{
+    public class ReconcilePaidBookingCommandHandler
+        : IRequestHandler<ReconcilePaidBookingCommand, OperationResult<BookingModel>>
+    {
+        private readonly IStripePaymentService _stripe;
+        private readonly IBookingRepository _bookingRepository;
+        private readonly IMediator _mediator;
+        private readonly ILogger<ReconcilePaidBookingCommandHandler> _logger;
+
+        public ReconcilePaidBookingCommandHandler(
+            IStripePaymentService stripe,
+            IBookingRepository bookingRepository,
+            IMediator mediator,
+            ILogger<ReconcilePaidBookingCommandHandler> logger)
+        {
+            _stripe = stripe;
+            _bookingRepository = bookingRepository;
+            _mediator = mediator;
+            _logger = logger;
+        }
+
+        public async Task<OperationResult<BookingModel>> Handle(
+            ReconcilePaidBookingCommand request, CancellationToken cancellationToken)
+        {
+            if (!_stripe.IsConfigured)
+            {
+                return OperationResult<BookingModel>.Failure("Betalning är inte konfigurerad.");
+            }
+
+            // Idempotens FÖRST (före Stripe-anrop och tidskontroller): är betalningen redan
+            // kopplad svarar vi alltid "redan kopplad" — även om tiden hunnit passera.
+            if (await _bookingRepository.ExistsByPaymentIntentIdAsync(request.PaymentIntentId))
+            {
+                return OperationResult<BookingModel>.Failure(
+                    "Betalningen är redan kopplad till en bokning.", OperationFailureType.Conflict);
+            }
+
+            var info = await _stripe.GetPaymentIntentAsync(request.PaymentIntentId, cancellationToken);
+            if (info == null)
+            {
+                return OperationResult<BookingModel>.Failure(
+                    "Betalningen kunde inte hämtas.", OperationFailureType.NotFound);
+            }
+            if (info.Status != "succeeded")
+            {
+                // T.ex. en redirect som ännu inte slutförts — webhooken tar den när den blir klar.
+                return OperationResult<BookingModel>.Failure("Betalningen är inte slutförd ännu.");
+            }
+            if (info.Refunded)
+            {
+                return OperationResult<BookingModel>.Failure("Betalningen är återbetald och kan inte användas.");
+            }
+
+            var m = info.Metadata;
+            if (!m.TryGetValue("userId", out var userId) || string.IsNullOrWhiteSpace(userId)
+                || !m.TryGetValue("serviceId", out var serviceIdStr) || !Guid.TryParse(serviceIdStr, out var serviceId)
+                || !m.TryGetValue("startTime", out var startStr)
+                || !DateTime.TryParse(startStr, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out var startTime)
+                || !m.TryGetValue("endTime", out var endStr)
+                || !DateTime.TryParse(endStr, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out var endTime))
+            {
+                _logger.LogError("PaymentIntent {PaymentIntentId} saknar bokningsuppgifter i metadatan", request.PaymentIntentId);
+                return OperationResult<BookingModel>.Failure("Betalningens bokningsuppgifter saknas.");
+            }
+            m.TryGetValue("employeeId", out var employeeId);
+
+            // Bokningstider är svensk väggtid med Kind=Unspecified (SwedishTime-kontraktet).
+            // Lås Kind explicit så en framtida offset i metadatan inte förskjuter tiden.
+            startTime = DateTime.SpecifyKind(startTime, DateTimeKind.Unspecified);
+            endTime = DateTime.SpecifyKind(endTime, DateTimeKind.Unspecified);
+
+            // Ägarskap: en inloggad användare får bara slutföra sin egen betalning.
+            // (Webhooken skickar RequestingUserId=null — där är Stripe-signaturen auktoriseringen.)
+            if (request.RequestingUserId != null && request.RequestingUserId != userId)
+            {
+                return OperationResult<BookingModel>.Failure(
+                    "Betalningen tillhör en annan användare.", OperationFailureType.Forbidden);
+            }
+
+            // Tiden hann passera innan avstämningen (t.ex. webhook-omleverans långt senare).
+            // En bokning bakåt i tiden är meningslös — återbetala istället för att låta
+            // valideringen kasta och pengarna fastna.
+            if (startTime <= SwedishTime.Now)
+            {
+                var refund = await _stripe.RefundAsync(
+                    request.PaymentIntentId, amountMinorUnit: null,
+                    idempotencyKey: $"reconcile-expired-refund-{request.PaymentIntentId}", cancellationToken);
+                _logger.LogWarning(
+                    "Betalning {PaymentIntentId} stämdes av efter att tiden passerat — återbetalning {Result}",
+                    request.PaymentIntentId, refund.Succeeded ? "genomförd" : "MISSLYCKADES");
+                return OperationResult<BookingModel>.Failure(refund.Succeeded
+                    ? "Tiden har redan passerat. Din betalning återbetalas automatiskt."
+                    : "Tiden har redan passerat och återbetalningen kunde inte genomföras — kontakta kliniken.");
+            }
+
+            // Återanvänd det ordinarie bokningsflödet: det verifierar beloppet mot Stripe,
+            // skyddar mot dubbel användning av samma betalning och auto-återbetalar vid
+            // slot-konflikt. Så både /payment-return och webhooken blir idempotenta.
+            var dto = new CreateBookingDTO
+            {
+                UserId = userId,
+                ServiceId = serviceId,
+                StartTime = startTime,
+                EndTime = endTime,
+                EmployeeId = employeeId ?? string.Empty,
+                PaymentIntentId = request.PaymentIntentId,
+            };
+            try
+            {
+                return await _mediator.Send(new CreateBookingCommand(dto), cancellationToken);
+            }
+            catch (ValidationException ex)
+            {
+                // Metadatan är serverside-satt så detta ska inte hända — men om det gör det
+                // får det aldrig bli en 500-loop mot Stripe (webhooks görs om i dagar).
+                _logger.LogError(ex, "Valideringsfel vid avstämning av betalning {PaymentIntentId}", request.PaymentIntentId);
+                return OperationResult<BookingModel>.Failure("Bokningsuppgifterna kunde inte valideras. Kontakta kliniken.");
+            }
+        }
+    }
+}

--- a/Application-Layer/Commands/PaymentCommands/CreatePaymentIntent/CreatePaymentIntentCommand.cs
+++ b/Application-Layer/Commands/PaymentCommands/CreatePaymentIntent/CreatePaymentIntentCommand.cs
@@ -1,0 +1,15 @@
+using Application_Layer.DTOs;
+using Domain_Layer.Common;
+using MediatR;
+
+namespace Application_Layer.Commands.PaymentCommands.CreatePaymentIntent
+{
+    /// <summary>
+    /// Skapar en Stripe PaymentIntent för onlinebetalning (hela priset) vid bokning.
+    /// Bokningsuppgifterna (tid/personal) läggs i PI-metadatan så betalningen kan
+    /// stämmas av till en bokning även via webhook om kunden aldrig kommer tillbaka.
+    /// </summary>
+    public sealed record CreatePaymentIntentCommand(
+        string UserId, Guid ServiceId, string EmployeeId, DateTime StartTime, DateTime EndTime)
+        : IRequest<OperationResult<PaymentIntentResponseDTO>>;
+}

--- a/Application-Layer/Commands/PaymentCommands/CreatePaymentIntent/CreatePaymentIntentCommandHandler.cs
+++ b/Application-Layer/Commands/PaymentCommands/CreatePaymentIntent/CreatePaymentIntentCommandHandler.cs
@@ -1,0 +1,96 @@
+using Application_Layer.Common;
+using Application_Layer.DTOs;
+using Application_Layer.Interfaces;
+using Domain_Layer.Common;
+using MediatR;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace Application_Layer.Commands.PaymentCommands.CreatePaymentIntent
+{
+    public class CreatePaymentIntentCommandHandler
+        : IRequestHandler<CreatePaymentIntentCommand, OperationResult<PaymentIntentResponseDTO>>
+    {
+        private readonly IUserRepository _userRepository;
+        private readonly IServiceRepository _serviceRepository;
+        private readonly IStripePaymentService _stripe;
+        private readonly IConfiguration _configuration;
+        private readonly ILogger<CreatePaymentIntentCommandHandler> _logger;
+
+        public CreatePaymentIntentCommandHandler(
+            IUserRepository userRepository,
+            IServiceRepository serviceRepository,
+            IStripePaymentService stripe,
+            IConfiguration configuration,
+            ILogger<CreatePaymentIntentCommandHandler> logger)
+        {
+            _userRepository = userRepository;
+            _serviceRepository = serviceRepository;
+            _stripe = stripe;
+            _configuration = configuration;
+            _logger = logger;
+        }
+
+        public async Task<OperationResult<PaymentIntentResponseDTO>> Handle(
+            CreatePaymentIntentCommand request, CancellationToken cancellationToken)
+        {
+            if (!_stripe.IsConfigured)
+            {
+                return OperationResult<PaymentIntentResponseDTO>.Failure("Betalning är inte konfigurerad.");
+            }
+
+            var user = await _userRepository.FindByIdAsync(request.UserId);
+            if (user == null)
+            {
+                return OperationResult<PaymentIntentResponseDTO>.Failure("User not found.", OperationFailureType.NotFound);
+            }
+
+            var service = await _serviceRepository.GetServiceByIdAsync(request.ServiceId);
+            if (service == null)
+            {
+                return OperationResult<PaymentIntentResponseDTO>.Failure("Behandlingen hittades inte.", OperationFailureType.NotFound);
+            }
+
+            try
+            {
+                var fullName = $"{user.FirstName} {user.LastName}".Trim();
+                var customerId = await _stripe.EnsureCustomerAsync(
+                    user.Id, user.Email, string.IsNullOrWhiteSpace(fullName) ? null : fullName,
+                    user.StripeCustomerId, cancellationToken);
+                if (customerId != user.StripeCustomerId)
+                {
+                    await _userRepository.SetStripeCustomerIdAsync(user.Id, customerId);
+                }
+
+                var currency = _configuration["Stripe:Currency"] ?? "sek";
+                var amountKr = service.Price;
+
+                var intent = await _stripe.CreatePaymentIntentAsync(
+                    customerId, PaymentAmounts.ToMinorUnit(amountKr), currency,
+                    $"Betalning för {service.Name}",
+                    // Bokningsuppgifter i metadatan → betalningen kan stämmas av till en
+                    // bokning via /payment-return ELLER webhook (orphan-skydd).
+                    new Dictionary<string, string>
+                    {
+                        ["userId"] = user.Id,
+                        ["serviceId"] = service.Id.ToString(),
+                        ["employeeId"] = request.EmployeeId ?? string.Empty,
+                        ["startTime"] = request.StartTime.ToString("o"),
+                        ["endTime"] = request.EndTime.ToString("o"),
+                    },
+                    cancellationToken);
+
+                return OperationResult<PaymentIntentResponseDTO>.Success(new PaymentIntentResponseDTO
+                {
+                    ClientSecret = intent.ClientSecret,
+                    Amount = amountKr,
+                });
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to create Stripe PaymentIntent for user {UserId}", request.UserId);
+                return OperationResult<PaymentIntentResponseDTO>.Failure("Kunde inte förbereda betalningen. Försök igen.");
+            }
+        }
+    }
+}

--- a/Application-Layer/Commands/PaymentCommands/CreateSetupIntent/CreateSetupIntentCommand.cs
+++ b/Application-Layer/Commands/PaymentCommands/CreateSetupIntent/CreateSetupIntentCommand.cs
@@ -1,0 +1,9 @@
+using Application_Layer.DTOs;
+using Domain_Layer.Common;
+using MediatR;
+
+namespace Application_Layer.Commands.PaymentCommands.CreateSetupIntent
+{
+    /// <summary>Skapar en Stripe SetupIntent så att den inloggade användaren kan spara ett kort (0 kr).</summary>
+    public sealed record CreateSetupIntentCommand(string UserId) : IRequest<OperationResult<SetupIntentResponseDTO>>;
+}

--- a/Application-Layer/Commands/PaymentCommands/CreateSetupIntent/CreateSetupIntentCommandHandler.cs
+++ b/Application-Layer/Commands/PaymentCommands/CreateSetupIntent/CreateSetupIntentCommandHandler.cs
@@ -1,0 +1,64 @@
+using Application_Layer.DTOs;
+using Application_Layer.Interfaces;
+using Domain_Layer.Common;
+using MediatR;
+using Microsoft.Extensions.Logging;
+
+namespace Application_Layer.Commands.PaymentCommands.CreateSetupIntent
+{
+    public class CreateSetupIntentCommandHandler
+        : IRequestHandler<CreateSetupIntentCommand, OperationResult<SetupIntentResponseDTO>>
+    {
+        private readonly IUserRepository _userRepository;
+        private readonly IStripePaymentService _stripe;
+        private readonly ILogger<CreateSetupIntentCommandHandler> _logger;
+
+        public CreateSetupIntentCommandHandler(
+            IUserRepository userRepository,
+            IStripePaymentService stripe,
+            ILogger<CreateSetupIntentCommandHandler> logger)
+        {
+            _userRepository = userRepository;
+            _stripe = stripe;
+            _logger = logger;
+        }
+
+        public async Task<OperationResult<SetupIntentResponseDTO>> Handle(
+            CreateSetupIntentCommand request, CancellationToken cancellationToken)
+        {
+            if (!_stripe.IsConfigured)
+            {
+                return OperationResult<SetupIntentResponseDTO>.Failure("Betalning är inte konfigurerad.");
+            }
+
+            var user = await _userRepository.FindByIdAsync(request.UserId);
+            if (user == null)
+            {
+                return OperationResult<SetupIntentResponseDTO>.Failure("User not found.", OperationFailureType.NotFound);
+            }
+
+            try
+            {
+                var fullName = $"{user.FirstName} {user.LastName}".Trim();
+                var customerId = await _stripe.EnsureCustomerAsync(
+                    user.Id, user.Email, string.IsNullOrWhiteSpace(fullName) ? null : fullName,
+                    user.StripeCustomerId, cancellationToken);
+
+                // Persistera customer-id:t om det just skapades.
+                if (customerId != user.StripeCustomerId)
+                {
+                    await _userRepository.SetStripeCustomerIdAsync(user.Id, customerId);
+                }
+
+                var clientSecret = await _stripe.CreateSetupIntentAsync(customerId, cancellationToken);
+                return OperationResult<SetupIntentResponseDTO>.Success(
+                    new SetupIntentResponseDTO { ClientSecret = clientSecret });
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to create Stripe SetupIntent for user {UserId}", request.UserId);
+                return OperationResult<SetupIntentResponseDTO>.Failure("Kunde inte förbereda kortbetalning. Försök igen.");
+            }
+        }
+    }
+}

--- a/Application-Layer/Common/BookingsReportCsvBuilder.cs
+++ b/Application-Layer/Common/BookingsReportCsvBuilder.cs
@@ -25,13 +25,15 @@ namespace Application_Layer.Common
                 sb.Append(row.Price.ToString("0.##", Swedish)).Append(';');
                 sb.Append(Escape(row.CustomerName)).Append(';');
                 sb.Append(Escape(row.EmployeeName)).Append(';');
-                sb.AppendLine(row.IsCancelled ? "Avbokad" : "Aktiv");
+                sb.AppendLine(row.IsCancelled ? "Avbokad" : row.IsNoShow ? "Utebliven" : "Aktiv");
             }
 
             sb.AppendLine();
             sb.Append("Totalt antal;").AppendLine(report.TotalBookings.ToString(Swedish));
-            sb.Append("Total omsättning (kr);").AppendLine(report.TotalRevenue.ToString("0.##", Swedish));
+            sb.Append("Bokat värde (kr);").AppendLine(report.TotalRevenue.ToString("0.##", Swedish));
+            sb.Append("Inbetalt online (kr);").AppendLine(report.AmountCollected.ToString("0.##", Swedish));
             sb.Append("Antal avbokningar;").AppendLine(report.CancelledBookings.ToString(Swedish));
+            sb.Append("Antal uteblivna;").AppendLine(report.NoShowBookings.ToString(Swedish));
 
             return sb.ToString();
         }

--- a/Application-Layer/Common/PaymentAmounts.cs
+++ b/Application-Layer/Common/PaymentAmounts.cs
@@ -1,0 +1,13 @@
+namespace Application_Layer.Common
+{
+    /// <summary>
+    /// Hjälpare för Stripe-belopp. Delas av PaymentIntent-skapandet och serverside-
+    /// verifieringen vid bokning så att samma belopp alltid gäller (klienten får inte
+    /// bestämma beloppet — det härleds alltid från behandlingens pris).
+    /// </summary>
+    public static class PaymentAmounts
+    {
+        /// <summary>kr → minsta enhet (öre).</summary>
+        public static long ToMinorUnit(decimal amountKr) => (long)Math.Round(amountKr * 100m);
+    }
+}

--- a/Application-Layer/DTOs/BookingDTO.cs
+++ b/Application-Layer/DTOs/BookingDTO.cs
@@ -22,6 +22,16 @@ namespace Application_Layer.DTOs
         public string? EmployeeName { get; set; }
         public string? ServiceName { get; set; }
 
+        // Livscykel + kort-på-fil-status (för FE-visning)
+        public string Status { get; set; } = "Active";
+        public bool HasSavedCard { get; set; }
+        public string? CardBrand { get; set; }
+        public string? CardLast4 { get; set; }
+
+        // Onlinebetalning
+        public string PaymentStatus { get; set; } = "None";
+        public decimal AmountPaid { get; set; }
+
         // Nested objects for full access
         public BookingUserDTO? User { get; set; }
         public BookingUserDTO? Employee { get; set; }

--- a/Application-Layer/DTOs/BookingsReportDTO.cs
+++ b/Application-Layer/DTOs/BookingsReportDTO.cs
@@ -10,6 +10,9 @@ namespace Application_Layer.DTOs
 
         /// <summary>Avbokad bokning. Räknas inte in i omsättning eller antal aktiva.</summary>
         public bool IsCancelled { get; set; }
+
+        /// <summary>Utebliven (no-show). Räknas inte in i behandlingsomsättningen — kunden betalade aldrig behandlingen.</summary>
+        public bool IsNoShow { get; set; }
     }
 
     public class BookingsReportServiceLineDTO
@@ -27,11 +30,17 @@ namespace Application_Layer.DTOs
         /// <summary>Antal aktiva (ej avbokade) bokningar i intervallet.</summary>
         public int TotalBookings { get; set; }
 
-        /// <summary>Omsättning från aktiva bokningar. Avbokade räknas inte in.</summary>
+        /// <summary>Bokat värde: pris för aktiva bokningar (prognos, ej nödvändigtvis inbetalt).</summary>
         public decimal TotalRevenue { get; set; }
+
+        /// <summary>Faktiskt inbetalt online (hela priset), exkl. återbetalt.</summary>
+        public decimal AmountCollected { get; set; }
 
         /// <summary>Antal avbokade bokningar i intervallet.</summary>
         public int CancelledBookings { get; set; }
+
+        /// <summary>Antal uteblivna (no-show) bokningar i intervallet.</summary>
+        public int NoShowBookings { get; set; }
 
         public List<BookingsReportServiceLineDTO> PerService { get; set; } = [];
 

--- a/Application-Layer/DTOs/CreateBookingDTO.cs
+++ b/Application-Layer/DTOs/CreateBookingDTO.cs
@@ -7,5 +7,11 @@ namespace Application_Layer.DTOs
         public DateTime StartTime { get; set; }
         public DateTime EndTime { get; set; }
         public string EmployeeId { get; set; } = string.Empty;
+
+        /// <summary>Stripe payment-method-id från det sparade kortet (betala på plats/kort-på-fil).</summary>
+        public string? PaymentMethodId { get; set; }
+
+        /// <summary>Stripe PaymentIntent-id om kunden betalade hela priset online.</summary>
+        public string? PaymentIntentId { get; set; }
     }
 }

--- a/Application-Layer/DTOs/PaymentIntentDtos.cs
+++ b/Application-Layer/DTOs/PaymentIntentDtos.cs
@@ -1,0 +1,24 @@
+namespace Application_Layer.DTOs
+{
+    /// <summary>Body för att skapa en PaymentIntent vid bokning (hela priset betalas online).</summary>
+    public class PaymentIntentRequestDTO
+    {
+        public Guid ServiceId { get; set; }
+        public string EmployeeId { get; set; } = string.Empty;
+        public DateTime StartTime { get; set; }
+        public DateTime EndTime { get; set; }
+    }
+
+    /// <summary>Svar med clientSecret + belopp (kr) som ska betalas.</summary>
+    public class PaymentIntentResponseDTO
+    {
+        public string ClientSecret { get; set; } = string.Empty;
+        public decimal Amount { get; set; }
+    }
+
+    /// <summary>Body för att slutföra en bokning efter en genomförd onlinebetalning (redirect-retur).</summary>
+    public class FinalizePaymentDTO
+    {
+        public string PaymentIntentId { get; set; } = string.Empty;
+    }
+}

--- a/Application-Layer/DTOs/SetupIntentResponseDTO.cs
+++ b/Application-Layer/DTOs/SetupIntentResponseDTO.cs
@@ -1,0 +1,8 @@
+namespace Application_Layer.DTOs
+{
+    /// <summary>Svar på skapad SetupIntent — clientSecret som frontend använder för att spara kortet via Stripe.js.</summary>
+    public class SetupIntentResponseDTO
+    {
+        public string ClientSecret { get; set; } = string.Empty;
+    }
+}

--- a/Application-Layer/DTOs/StripePaymentDtos.cs
+++ b/Application-Layer/DTOs/StripePaymentDtos.cs
@@ -1,0 +1,31 @@
+namespace Application_Layer.DTOs
+{
+    /// <summary>Kortmärke + sista fyra siffror, för visning ("Visa ••4242"). Aldrig fullt kortnummer.</summary>
+    public sealed record CardDetails(string Brand, string Last4);
+
+    /// <summary>Resultat av en off-session-debitering (no-show-avgift).</summary>
+    public sealed record StripeChargeResult(bool Succeeded, string? PaymentIntentId, string? Status, string? Error);
+
+    /// <summary>Nyskapad PaymentIntent för onlinebetalning vid bokning.</summary>
+    public sealed record PaymentIntentResult(string ClientSecret, string PaymentIntentId);
+
+    /// <summary>
+    /// Läst status för en PaymentIntent (serverside-verifiering av att betalning skett).
+    /// Metadata bär bokningsuppgifterna (serverside-satta) så en betalning kan stämmas av
+    /// till en bokning även via webhook (kund som stänger fliken mitt i en redirect).
+    /// Refunded behövs för att Stripe låter status vara "succeeded" även efter återbetalning
+    /// — utan flaggan kunde en redan återbetald betalning ge en ny bokning.
+    /// </summary>
+    public sealed record PaymentIntentInfo(
+        string Status, long AmountReceivedMinorUnit, bool Refunded,
+        IReadOnlyDictionary<string, string> Metadata);
+
+    /// <summary>Resultat av en återbetalning.</summary>
+    public sealed record StripeRefundResult(bool Succeeded, string? Error);
+
+    /// <summary>
+    /// Neutral projektion av en verifierad Stripe-webhook-event — så att Stripe-SDK-typer
+    /// aldrig läcker ut i API-/Application-lagret. Null returneras vid ogiltig signatur.
+    /// </summary>
+    public sealed record StripeWebhookResult(string Type, string? PaymentIntentId, string? BookingId, string? Error);
+}

--- a/Application-Layer/Interfaces/IBookingRepository.cs
+++ b/Application-Layer/Interfaces/IBookingRepository.cs
@@ -26,6 +26,12 @@ namespace Application_Layer.Interfaces
         Task AddAsync(BookingModel booking);
         Task<bool> TryAddIfNoConflictAsync(BookingModel booking);
         Task<bool> HasConflictAsync(Guid excludeBookingId, string employeeId, DateTime start, DateTime end);
+
+        /// <summary>
+        /// Finns en bokning (oavsett status) som redan använt denna Stripe-betalning?
+        /// Skydd mot att samma PaymentIntent återanvänds för flera bokningar.
+        /// </summary>
+        Task<bool> ExistsByPaymentIntentIdAsync(string paymentIntentId);
         Task UpdateAsync(BookingModel booking);
         Task<List<BookingModel>> GetAllAsync();
     }

--- a/Application-Layer/Interfaces/IStripePaymentService.cs
+++ b/Application-Layer/Interfaces/IStripePaymentService.cs
@@ -1,0 +1,49 @@
+using Application_Layer.DTOs;
+
+namespace Application_Layer.Interfaces
+{
+    /// <summary>
+    /// Stripe-integration för kort-på-fil: spara kort utan debitering (SetupIntent) vid bokning,
+    /// och dra no-show-avgift off-session från sparat kort. Stripe håller korten — vi lagrar bara
+    /// referens-id (customer/paymentMethod). Utan konfigurerade nycklar körs NullStripePaymentService.
+    /// </summary>
+    public interface IStripePaymentService
+    {
+        /// <summary>Är Stripe konfigurerat (nycklar satta)? Styr om kort-steget krävs vid bokning.</summary>
+        bool IsConfigured { get; }
+
+        /// <summary>Hämtar befintlig eller skapar en Stripe-customer för användaren. Returnerar customerId.</summary>
+        Task<string> EnsureCustomerAsync(string userId, string? email, string? name, string? existingCustomerId, CancellationToken ct);
+
+        /// <summary>Skapar en SetupIntent (spara kort, 0 kr) för customern. Returnerar clientSecret till frontend.</summary>
+        Task<string> CreateSetupIntentAsync(string customerId, CancellationToken ct);
+
+        /// <summary>Skapar en PaymentIntent (debitera belopp online vid bokning). Returnerar clientSecret + id.</summary>
+        Task<PaymentIntentResult> CreatePaymentIntentAsync(
+            string customerId, long amountMinorUnit, string currency, string description,
+            IDictionary<string, string>? metadata, CancellationToken ct);
+
+        /// <summary>Läser en PaymentIntents status/belopp — för serverside-verifiering att betalningen gick igenom.</summary>
+        Task<PaymentIntentInfo?> GetPaymentIntentAsync(string paymentIntentId, CancellationToken ct);
+
+        /// <summary>Återbetalar en tidigare onlinebetalning (helt om amountMinorUnit är null).</summary>
+        Task<StripeRefundResult> RefundAsync(
+            string paymentIntentId, long? amountMinorUnit, string idempotencyKey, CancellationToken ct);
+
+        /// <summary>Hämtar kortmärke + sista fyra för ett sparat betalningssätt (för visning).</summary>
+        Task<CardDetails?> GetCardDetailsAsync(string paymentMethodId, CancellationToken ct);
+
+        /// <summary>
+        /// Drar ett belopp (minsta enhet, t.ex. öre) off-session från sparat kort.
+        /// idempotencyKey gör att ett omförsök (t.ex. efter att DB-uppdateringen
+        /// misslyckats mellan debitering och statusändring) inte dubbeldebiterar —
+        /// Stripe återanvänder samma PaymentIntent för samma nyckel.
+        /// </summary>
+        Task<StripeChargeResult> ChargeOffSessionAsync(
+            string customerId, string paymentMethodId, long amountMinorUnit, string currency,
+            string description, IDictionary<string, string>? metadata, string idempotencyKey, CancellationToken ct);
+
+        /// <summary>Verifierar signatur och tolkar en webhook-payload. Null vid ogiltig signatur.</summary>
+        StripeWebhookResult? ParseWebhook(string json, string signatureHeader);
+    }
+}

--- a/Application-Layer/Interfaces/IUserRepository.cs
+++ b/Application-Layer/Interfaces/IUserRepository.cs
@@ -35,6 +35,8 @@ namespace Application_Layer.Interfaces
         /// e-posten), Customer-roll, och den externa loginen kopplas.
         /// </summary>
         Task<OperationResult> RegisterExternalUserAsync(UserModel newUser, string provider, string providerKey);
+        /// <summary>Sparar Stripe-customer-id på användaren (kort-på-fil). Rör inga andra fält.</summary>
+        Task<OperationResult> SetStripeCustomerIdAsync(string userId, string stripeCustomerId);
         Task<UserModel?> GetFirstEmployeeAsync();
         Task<List<UserModel>> GetEmployeesAsync();
         Task<IList<string>> GetRolesAsync(UserModel user);

--- a/Application-Layer/Mapping/ApplicationMapper.cs
+++ b/Application-Layer/Mapping/ApplicationMapper.cs
@@ -28,6 +28,12 @@ namespace Application_Layer.Mapping
             CustomerName = FullName(b.User),
             EmployeeName = FullName(b.Employee),
             ServiceName = b.Service?.Name,
+            Status = b.Status.ToString(),
+            HasSavedCard = !string.IsNullOrWhiteSpace(b.StripePaymentMethodId),
+            CardBrand = b.CardBrand,
+            CardLast4 = b.CardLast4,
+            PaymentStatus = b.PaymentStatus.ToString(),
+            AmountPaid = b.AmountPaid,
             User = ToBookingUserDto(b.User),
             Employee = ToBookingUserDto(b.Employee),
         };
@@ -37,6 +43,14 @@ namespace Application_Layer.Mapping
         [MapperIgnoreTarget(nameof(BookingModel.Id))]
         [MapperIgnoreTarget(nameof(BookingModel.ConversationId))]
         [MapperIgnoreTarget(nameof(BookingModel.Status))]
+        [MapperIgnoreTarget(nameof(BookingModel.ReminderSentAt))]
+        [MapperIgnoreTarget(nameof(BookingModel.StripePaymentMethodId))]
+        [MapperIgnoreTarget(nameof(BookingModel.CardBrand))]
+        [MapperIgnoreTarget(nameof(BookingModel.CardLast4))]
+        [MapperIgnoreTarget(nameof(BookingModel.NoShowFeeChargedAt))]
+        [MapperIgnoreTarget(nameof(BookingModel.PaymentStatus))]
+        [MapperIgnoreTarget(nameof(BookingModel.AmountPaid))]
+        [MapperIgnoreTarget(nameof(BookingModel.StripePaymentIntentId))]
         [MapperIgnoreTarget(nameof(BookingModel.User))]
         [MapperIgnoreTarget(nameof(BookingModel.Employee))]
         [MapperIgnoreTarget(nameof(BookingModel.Service))]
@@ -46,6 +60,14 @@ namespace Application_Layer.Mapping
         [MapperIgnoreTarget(nameof(BookingModel.UserId))]
         [MapperIgnoreTarget(nameof(BookingModel.ConversationId))]
         [MapperIgnoreTarget(nameof(BookingModel.Status))]
+        [MapperIgnoreTarget(nameof(BookingModel.ReminderSentAt))]
+        [MapperIgnoreTarget(nameof(BookingModel.StripePaymentMethodId))]
+        [MapperIgnoreTarget(nameof(BookingModel.CardBrand))]
+        [MapperIgnoreTarget(nameof(BookingModel.CardLast4))]
+        [MapperIgnoreTarget(nameof(BookingModel.NoShowFeeChargedAt))]
+        [MapperIgnoreTarget(nameof(BookingModel.PaymentStatus))]
+        [MapperIgnoreTarget(nameof(BookingModel.AmountPaid))]
+        [MapperIgnoreTarget(nameof(BookingModel.StripePaymentIntentId))]
         [MapperIgnoreTarget(nameof(BookingModel.User))]
         [MapperIgnoreTarget(nameof(BookingModel.Employee))]
         [MapperIgnoreTarget(nameof(BookingModel.Service))]

--- a/Application-Layer/Queries/BookingQueries/GetBookingsReport/GetBookingsReportQueryHandler.cs
+++ b/Application-Layer/Queries/BookingQueries/GetBookingsReport/GetBookingsReportQueryHandler.cs
@@ -32,12 +32,14 @@ namespace Application_Layer.Queries.BookingQueries.GetBookingsReport
                     CustomerName = FormatName(b.User?.FirstName, b.User?.LastName),
                     EmployeeName = FormatName(b.Employee?.FirstName, b.Employee?.LastName),
                     IsCancelled = b.Status == BookingStatus.Cancelled,
+                    IsNoShow = b.Status == BookingStatus.NoShow,
                 })
                 .ToList();
 
-            // Omsättning och antal räknas bara på aktiva bokningar — avbokade
-            // gav ingen intäkt och ska inte blåsa upp siffrorna.
-            var activeRows = rows.Where(r => !r.IsCancelled).ToList();
+            // Omsättning och antal räknas bara på aktiva bokningar — avbokade och
+            // uteblivna gav ingen behandlingsintäkt och ska inte blåsa upp siffrorna.
+            // (No-show-avgiften bokförs hos Stripe och ingår inte här.)
+            var activeRows = rows.Where(r => !r.IsCancelled && !r.IsNoShow).ToList();
 
             var perService = activeRows
                 .GroupBy(r => r.ServiceName)
@@ -56,7 +58,12 @@ namespace Application_Layer.Queries.BookingQueries.GetBookingsReport
                 To = request.To.Date,
                 TotalBookings = activeRows.Count,
                 TotalRevenue = activeRows.Sum(r => r.Price),
-                CancelledBookings = rows.Count - activeRows.Count,
+                // Faktiskt inbetalt online (hela priset), återbetalt exkluderas.
+                AmountCollected = bookings
+                    .Where(b => b.PaymentStatus == PaymentStatus.PaidInFull)
+                    .Sum(b => b.AmountPaid),
+                CancelledBookings = rows.Count(r => r.IsCancelled),
+                NoShowBookings = rows.Count(r => r.IsNoShow),
                 PerService = perService,
                 Rows = rows,
             };

--- a/Domain-Layer/Models/BookingModel.cs
+++ b/Domain-Layer/Models/BookingModel.cs
@@ -25,6 +25,27 @@ namespace Domain_Layer.Models
         /// </summary>
         public DateTime? ReminderSentAt { get; set; }
 
+        /// <summary>Stripe payment-method-id för kortet som sparades vid bokning (no-show debiteras detta). Null = kortlös bokning.</summary>
+        public string? StripePaymentMethodId { get; set; }
+
+        /// <summary>Kortmärke för visning ("Visa"), aldrig fullt kortnummer.</summary>
+        public string? CardBrand { get; set; }
+
+        /// <summary>Kortets sista fyra siffror för visning.</summary>
+        public string? CardLast4 { get; set; }
+
+        /// <summary>När no-show-avgiften drogs. Null = ej debiterad. Idempotensspärr så avgiften inte dras två gånger.</summary>
+        public DateTime? NoShowFeeChargedAt { get; set; }
+
+        /// <summary>Betalningsstatus för onlinebetalning. None = betala på plats (kort-på-fil).</summary>
+        public PaymentStatus PaymentStatus { get; set; } = PaymentStatus.None;
+
+        /// <summary>Belopp (kr) som faktiskt debiterats online (hela priset). 0 = inget dragits.</summary>
+        public decimal AmountPaid { get; set; }
+
+        /// <summary>Stripe PaymentIntent-id för onlinebetalningen (används vid återbetalning). Null = ingen onlinebetalning.</summary>
+        public string? StripePaymentIntentId { get; set; }
+
         // Navigation properties
         public UserModel? User { get; set; }
         public UserModel? Employee { get; set; }
@@ -37,6 +58,22 @@ namespace Domain_Layer.Models
         Active,
 
         /// <summary>Avbokad. Behålls i databasen för uppföljning/rapportering.</summary>
-        Cancelled
+        Cancelled,
+
+        /// <summary>Utebliven (no-show). Sätts av personal på en passerad bokning; triggar no-show-avgift.</summary>
+        NoShow
+    }
+
+    /// <summary>Onlinebetalningens status för en bokning.</summary>
+    public enum PaymentStatus
+    {
+        /// <summary>Ingen onlinebetalning — kunden betalar på plats (ev. kort-på-fil för no-show).</summary>
+        None,
+
+        /// <summary>Hela beloppet betalt online.</summary>
+        PaidInFull,
+
+        /// <summary>Onlinebetalningen är återbetalad (avbokning i tid).</summary>
+        Refunded
     }
 }

--- a/Domain-Layer/Models/NotificationModel.cs
+++ b/Domain-Layer/Models/NotificationModel.cs
@@ -22,5 +22,7 @@ public enum NotificationType
     BookingConfirmation,
     BookingCancellation,
     BookingUpdated,
-    MessageReceived
+    MessageReceived,
+    NoShowFeeCharged,
+    PaymentFailed
 }

--- a/Domain-Layer/Models/UserModel.cs
+++ b/Domain-Layer/Models/UserModel.cs
@@ -11,5 +11,6 @@ namespace Domain_Layer.Models
         public bool IsDeleted { get; set; }
         public string? AvatarUrl { get; set; }
         public bool EmailConfirmed { get; set; }
+        public string? StripeCustomerId { get; set; }
     }
 }

--- a/Infrastructure-Layer/Database/ElsaBeautyDbContext.cs
+++ b/Infrastructure-Layer/Database/ElsaBeautyDbContext.cs
@@ -89,6 +89,23 @@ namespace Infrastructure_Layer.Database
                     .HasMaxLength(20)
                     .HasDefaultValue(BookingStatus.Active);
 
+                // Betalningsstatus som läsbar sträng, default None (betala på plats).
+                entity.Property(b => b.PaymentStatus)
+                    .HasConversion<string>()
+                    .HasMaxLength(20)
+                    .HasDefaultValue(PaymentStatus.None);
+
+                entity.Property(b => b.AmountPaid)
+                    .HasColumnType("decimal(10,2)");
+
+                // Unikt (filtrerat) index: en Stripe-betalning får bara ge EN bokning.
+                // Gör PI-vakten atomär — returflödet och webhooken kan tävla om samma
+                // betalning, och utan indexet kunde båda passera exists-kontrollen.
+                entity.Property(b => b.StripePaymentIntentId).HasMaxLength(255);
+                entity.HasIndex(b => b.StripePaymentIntentId)
+                    .IsUnique()
+                    .HasFilter("[StripePaymentIntentId] IS NOT NULL");
+
                 entity.HasOne<ApplicationUser>()
                     .WithMany()
                     .HasForeignKey(b => b.UserId)

--- a/Infrastructure-Layer/DependencyInjection.cs
+++ b/Infrastructure-Layer/DependencyInjection.cs
@@ -1,5 +1,6 @@
 using Application_Layer.Interfaces;
 using Application_Layer.Jwt;
+using Microsoft.Extensions.Logging;
 using Azure.Communication.Email;
 using Azure.Communication.Sms;
 using Azure.Storage.Blobs;
@@ -74,6 +75,20 @@ namespace Infrastructure_Layer
             {
                 services.AddScoped<IEmailSender, NullEmailSender>();
                 services.AddScoped<ISmsSender, NullSmsSender>();
+            }
+
+            var stripeSecretKey = configuration["Stripe:SecretKey"];
+            if (!string.IsNullOrWhiteSpace(stripeSecretKey))
+            {
+                var stripeWebhookSecret = configuration["Stripe:WebhookSecret"];
+                services.AddScoped<IStripePaymentService>(sp => new Services.StripePaymentService(
+                    stripeSecretKey,
+                    stripeWebhookSecret,
+                    sp.GetRequiredService<ILogger<Services.StripePaymentService>>()));
+            }
+            else
+            {
+                services.AddScoped<IStripePaymentService, Services.NullStripePaymentService>();
             }
 
             return services;

--- a/Infrastructure-Layer/Identity/ApplicationUser.cs
+++ b/Infrastructure-Layer/Identity/ApplicationUser.cs
@@ -10,4 +10,7 @@ public class ApplicationUser : IdentityUser
 
     /// <summary>Blob-path till profilbilden ("&lt;container&gt;/&lt;blobNamn&gt;") — aldrig en färdig URL.</summary>
     public string? AvatarUrl { get; set; }
+
+    /// <summary>Stripe-customer-id för kort-på-fil. Null tills första kortet sparas.</summary>
+    public string? StripeCustomerId { get; set; }
 }

--- a/Infrastructure-Layer/Infrastructure-Layer.csproj
+++ b/Infrastructure-Layer/Infrastructure-Layer.csproj
@@ -27,6 +27,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
+    <PackageReference Include="Stripe.net" Version="52.1.0" />
   </ItemGroup>
 
 </Project>

--- a/Infrastructure-Layer/Migrations/20260712123328_AddStripePaymentFields.Designer.cs
+++ b/Infrastructure-Layer/Migrations/20260712123328_AddStripePaymentFields.Designer.cs
@@ -4,6 +4,7 @@ using Infrastructure_Layer.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Infrastructure_Layer.Migrations
 {
     [DbContext(typeof(ElsaBeautyDbContext))]
-    partial class ElsaBeautyDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260712123328_AddStripePaymentFields")]
+    partial class AddStripePaymentFields
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -27,9 +30,6 @@ namespace Infrastructure_Layer.Migrations
                     b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
                         .HasColumnType("uniqueidentifier");
-
-                    b.Property<decimal>("AmountPaid")
-                        .HasColumnType("decimal(10,2)");
 
                     b.Property<string>("CardBrand")
                         .HasColumnType("nvarchar(max)");
@@ -49,13 +49,6 @@ namespace Infrastructure_Layer.Migrations
                     b.Property<DateTime?>("NoShowFeeChargedAt")
                         .HasColumnType("datetime2");
 
-                    b.Property<string>("PaymentStatus")
-                        .IsRequired()
-                        .ValueGeneratedOnAdd()
-                        .HasMaxLength(20)
-                        .HasColumnType("nvarchar(20)")
-                        .HasDefaultValue("None");
-
                     b.Property<DateTime?>("ReminderSentAt")
                         .HasColumnType("datetime2");
 
@@ -72,10 +65,6 @@ namespace Infrastructure_Layer.Migrations
                         .HasColumnType("nvarchar(20)")
                         .HasDefaultValue("Active");
 
-                    b.Property<string>("StripePaymentIntentId")
-                        .HasMaxLength(255)
-                        .HasColumnType("nvarchar(255)");
-
                     b.Property<string>("StripePaymentMethodId")
                         .HasColumnType("nvarchar(max)");
 
@@ -88,10 +77,6 @@ namespace Infrastructure_Layer.Migrations
                     b.HasIndex("EmployeeId");
 
                     b.HasIndex("ServiceId");
-
-                    b.HasIndex("StripePaymentIntentId")
-                        .IsUnique()
-                        .HasFilter("[StripePaymentIntentId] IS NOT NULL");
 
                     b.HasIndex("UserId");
 

--- a/Infrastructure-Layer/Migrations/20260712123328_AddStripePaymentFields.cs
+++ b/Infrastructure-Layer/Migrations/20260712123328_AddStripePaymentFields.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Infrastructure_Layer.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddStripePaymentFields : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "CardBrand",
+                table: "Bookings",
+                type: "nvarchar(max)",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "CardLast4",
+                table: "Bookings",
+                type: "nvarchar(max)",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "NoShowFeeChargedAt",
+                table: "Bookings",
+                type: "datetime2",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "StripePaymentMethodId",
+                table: "Bookings",
+                type: "nvarchar(max)",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "StripeCustomerId",
+                table: "AspNetUsers",
+                type: "nvarchar(max)",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "CardBrand",
+                table: "Bookings");
+
+            migrationBuilder.DropColumn(
+                name: "CardLast4",
+                table: "Bookings");
+
+            migrationBuilder.DropColumn(
+                name: "NoShowFeeChargedAt",
+                table: "Bookings");
+
+            migrationBuilder.DropColumn(
+                name: "StripePaymentMethodId",
+                table: "Bookings");
+
+            migrationBuilder.DropColumn(
+                name: "StripeCustomerId",
+                table: "AspNetUsers");
+        }
+    }
+}

--- a/Infrastructure-Layer/Migrations/20260713234123_AddBookingPaymentStatus.Designer.cs
+++ b/Infrastructure-Layer/Migrations/20260713234123_AddBookingPaymentStatus.Designer.cs
@@ -4,6 +4,7 @@ using Infrastructure_Layer.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Infrastructure_Layer.Migrations
 {
     [DbContext(typeof(ElsaBeautyDbContext))]
-    partial class ElsaBeautyDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260713234123_AddBookingPaymentStatus")]
+    partial class AddBookingPaymentStatus
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -73,8 +76,7 @@ namespace Infrastructure_Layer.Migrations
                         .HasDefaultValue("Active");
 
                     b.Property<string>("StripePaymentIntentId")
-                        .HasMaxLength(255)
-                        .HasColumnType("nvarchar(255)");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("StripePaymentMethodId")
                         .HasColumnType("nvarchar(max)");
@@ -88,10 +90,6 @@ namespace Infrastructure_Layer.Migrations
                     b.HasIndex("EmployeeId");
 
                     b.HasIndex("ServiceId");
-
-                    b.HasIndex("StripePaymentIntentId")
-                        .IsUnique()
-                        .HasFilter("[StripePaymentIntentId] IS NOT NULL");
 
                     b.HasIndex("UserId");
 

--- a/Infrastructure-Layer/Migrations/20260713234123_AddBookingPaymentStatus.cs
+++ b/Infrastructure-Layer/Migrations/20260713234123_AddBookingPaymentStatus.cs
@@ -1,0 +1,51 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Infrastructure_Layer.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddBookingPaymentStatus : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<decimal>(
+                name: "AmountPaid",
+                table: "Bookings",
+                type: "decimal(10,2)",
+                nullable: false,
+                defaultValue: 0m);
+
+            migrationBuilder.AddColumn<string>(
+                name: "PaymentStatus",
+                table: "Bookings",
+                type: "nvarchar(20)",
+                maxLength: 20,
+                nullable: false,
+                defaultValue: "None");
+
+            migrationBuilder.AddColumn<string>(
+                name: "StripePaymentIntentId",
+                table: "Bookings",
+                type: "nvarchar(max)",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "AmountPaid",
+                table: "Bookings");
+
+            migrationBuilder.DropColumn(
+                name: "PaymentStatus",
+                table: "Bookings");
+
+            migrationBuilder.DropColumn(
+                name: "StripePaymentIntentId",
+                table: "Bookings");
+        }
+    }
+}

--- a/Infrastructure-Layer/Migrations/20260716005049_AddBookingPaymentIntentUniqueIndex.Designer.cs
+++ b/Infrastructure-Layer/Migrations/20260716005049_AddBookingPaymentIntentUniqueIndex.Designer.cs
@@ -4,6 +4,7 @@ using Infrastructure_Layer.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Infrastructure_Layer.Migrations
 {
     [DbContext(typeof(ElsaBeautyDbContext))]
-    partial class ElsaBeautyDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260716005049_AddBookingPaymentIntentUniqueIndex")]
+    partial class AddBookingPaymentIntentUniqueIndex
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Infrastructure-Layer/Migrations/20260716005049_AddBookingPaymentIntentUniqueIndex.cs
+++ b/Infrastructure-Layer/Migrations/20260716005049_AddBookingPaymentIntentUniqueIndex.cs
@@ -1,0 +1,49 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Infrastructure_Layer.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddBookingPaymentIntentUniqueIndex : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "StripePaymentIntentId",
+                table: "Bookings",
+                type: "nvarchar(255)",
+                maxLength: 255,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)",
+                oldNullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Bookings_StripePaymentIntentId",
+                table: "Bookings",
+                column: "StripePaymentIntentId",
+                unique: true,
+                filter: "[StripePaymentIntentId] IS NOT NULL");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_Bookings_StripePaymentIntentId",
+                table: "Bookings");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "StripePaymentIntentId",
+                table: "Bookings",
+                type: "nvarchar(max)",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(255)",
+                oldMaxLength: 255,
+                oldNullable: true);
+        }
+    }
+}

--- a/Infrastructure-Layer/Repositories/Booking/BookingRepository.cs
+++ b/Infrastructure-Layer/Repositories/Booking/BookingRepository.cs
@@ -45,6 +45,12 @@ namespace Infrastructure_Layer.Repositories
                 b.StartTime < end && b.EndTime > start);
         }
 
+        public async Task<bool> ExistsByPaymentIntentIdAsync(string paymentIntentId)
+        {
+            // Oavsett status: även en avbokad/återbetald bokning "förbrukar" sin betalning.
+            return await _context.Bookings.AnyAsync(b => b.StripePaymentIntentId == paymentIntentId);
+        }
+
         public async Task<bool> TryAddIfNoConflictAsync(BookingModel booking)
         {
             try
@@ -82,9 +88,13 @@ namespace Infrastructure_Layer.Repositories
 
         public async Task<List<BookingModel>> GetByUserIdAsync(string userId)
         {
+            // Aktiva + uteblivna visas. Uteblivna MÅSTE synas för kunden — de har
+            // debiterats en no-show-avgift och behöver se bokningen det gäller.
+            // Avbokade döljs fortsatt (medvetet, som tidigare beteende).
             var bookings = await _context.Bookings
                 .Include(b => b.Service)
-                .Where(b => b.UserId == userId && b.Status == BookingStatus.Active)
+                .Where(b => b.UserId == userId &&
+                    (b.Status == BookingStatus.Active || b.Status == BookingStatus.NoShow))
                 .ToListAsync();
 
             await PopulateUsersAsync(bookings);

--- a/Infrastructure-Layer/Repositories/User/UserRepository.cs
+++ b/Infrastructure-Layer/Repositories/User/UserRepository.cs
@@ -256,6 +256,19 @@ namespace Infrastructure_Layer.Repositories.User
             return OperationResult.Success();
         }
 
+        public async Task<OperationResult> SetStripeCustomerIdAsync(string userId, string stripeCustomerId)
+        {
+            var identityUser = await _userManager.FindByIdAsync(userId);
+            if (identityUser == null)
+            {
+                return OperationResult.Failure("User not found.", OperationFailureType.NotFound);
+            }
+
+            identityUser.StripeCustomerId = stripeCustomerId;
+            var result = await _userManager.UpdateAsync(identityUser);
+            return ToOperationResult(result);
+        }
+
         public async Task<UserModel?> GetFirstEmployeeAsync()
         {
             var employees = await _userManager.GetUsersInRoleAsync("Employee");
@@ -309,7 +322,8 @@ namespace Infrastructure_Layer.Repositories.User
                 LastName = user.LastName,
                 IsDeleted = user.IsDeleted,
                 AvatarUrl = user.AvatarUrl,
-                EmailConfirmed = user.EmailConfirmed
+                EmailConfirmed = user.EmailConfirmed,
+                StripeCustomerId = user.StripeCustomerId
             };
         }
 

--- a/Infrastructure-Layer/Services/NullStripePaymentService.cs
+++ b/Infrastructure-Layer/Services/NullStripePaymentService.cs
@@ -1,0 +1,43 @@
+using Application_Layer.DTOs;
+using Application_Layer.Interfaces;
+
+namespace Infrastructure_Layer.Services
+{
+    /// <summary>
+    /// Används när Stripe inte är konfigurerat (t.ex. lokal dev utan nycklar). Bokning
+    /// fungerar då kortlöst och kort-steget döljs i frontend (IsConfigured = false).
+    /// Faktiska betaloperationer ska aldrig anropas i det läget.
+    /// </summary>
+    public sealed class NullStripePaymentService : IStripePaymentService
+    {
+        public bool IsConfigured => false;
+
+        public Task<string> EnsureCustomerAsync(string userId, string? email, string? name, string? existingCustomerId, CancellationToken ct)
+            => throw new InvalidOperationException("Stripe is not configured.");
+
+        public Task<string> CreateSetupIntentAsync(string customerId, CancellationToken ct)
+            => throw new InvalidOperationException("Stripe is not configured.");
+
+        public Task<PaymentIntentResult> CreatePaymentIntentAsync(
+            string customerId, long amountMinorUnit, string currency, string description,
+            IDictionary<string, string>? metadata, CancellationToken ct)
+            => throw new InvalidOperationException("Stripe is not configured.");
+
+        public Task<PaymentIntentInfo?> GetPaymentIntentAsync(string paymentIntentId, CancellationToken ct)
+            => Task.FromResult<PaymentIntentInfo?>(null);
+
+        public Task<StripeRefundResult> RefundAsync(
+            string paymentIntentId, long? amountMinorUnit, string idempotencyKey, CancellationToken ct)
+            => throw new InvalidOperationException("Stripe is not configured.");
+
+        public Task<CardDetails?> GetCardDetailsAsync(string paymentMethodId, CancellationToken ct)
+            => Task.FromResult<CardDetails?>(null);
+
+        public Task<StripeChargeResult> ChargeOffSessionAsync(
+            string customerId, string paymentMethodId, long amountMinorUnit, string currency,
+            string description, IDictionary<string, string>? metadata, string idempotencyKey, CancellationToken ct)
+            => throw new InvalidOperationException("Stripe is not configured.");
+
+        public StripeWebhookResult? ParseWebhook(string json, string signatureHeader) => null;
+    }
+}

--- a/Infrastructure-Layer/Services/StripePaymentService.cs
+++ b/Infrastructure-Layer/Services/StripePaymentService.cs
@@ -1,0 +1,202 @@
+using Application_Layer.DTOs;
+using Application_Layer.Interfaces;
+using Microsoft.Extensions.Logging;
+using Stripe;
+
+namespace Infrastructure_Layer.Services
+{
+    /// <summary>
+    /// Stripe.net-baserad implementation av kort-på-fil. Registreras endast när
+    /// Stripe:SecretKey finns (annars NullStripePaymentService). All kortdata bor hos
+    /// Stripe; vi hanterar bara customer-/paymentMethod-id och verifierade webhooks.
+    /// </summary>
+    public class StripePaymentService : IStripePaymentService
+    {
+        private readonly StripeClient _client;
+        private readonly string _webhookSecret;
+        private readonly ILogger<StripePaymentService> _logger;
+
+        public StripePaymentService(string secretKey, string? webhookSecret, ILogger<StripePaymentService> logger)
+        {
+            _client = new StripeClient(secretKey);
+            _webhookSecret = webhookSecret ?? string.Empty;
+            _logger = logger;
+        }
+
+        public bool IsConfigured => true;
+
+        public async Task<string> EnsureCustomerAsync(
+            string userId, string? email, string? name, string? existingCustomerId, CancellationToken ct)
+        {
+            if (!string.IsNullOrWhiteSpace(existingCustomerId))
+            {
+                return existingCustomerId;
+            }
+
+            var customerService = new CustomerService(_client);
+            var customer = await customerService.CreateAsync(new CustomerCreateOptions
+            {
+                Email = email,
+                Name = name,
+                Metadata = new Dictionary<string, string> { ["userId"] = userId },
+            }, cancellationToken: ct);
+
+            return customer.Id;
+        }
+
+        public async Task<string> CreateSetupIntentAsync(string customerId, CancellationToken ct)
+        {
+            var service = new SetupIntentService(_client);
+            var intent = await service.CreateAsync(new SetupIntentCreateOptions
+            {
+                Customer = customerId,
+                PaymentMethodTypes = ["card"],
+                Usage = "off_session", // vi ska kunna dra kortet senare utan kunden närvarande
+            }, cancellationToken: ct);
+
+            return intent.ClientSecret;
+        }
+
+        public async Task<PaymentIntentResult> CreatePaymentIntentAsync(
+            string customerId, long amountMinorUnit, string currency, string description,
+            IDictionary<string, string>? metadata, CancellationToken ct)
+        {
+            var service = new PaymentIntentService(_client);
+            var intent = await service.CreateAsync(new PaymentIntentCreateOptions
+            {
+                Amount = amountMinorUnit,
+                Currency = currency,
+                Customer = customerId,
+                Description = description,
+                Metadata = metadata == null ? null : new Dictionary<string, string>(metadata),
+                // Explicit lista: kort (inkl. Google Pay/Apple Pay-wallets) + Klarna + Amazon Pay.
+                // Klarna och Amazon Pay är redirect-metoder — FE skickar return_url vid
+                // confirmPayment och /payment-return slutför bokningen.
+                PaymentMethodTypes = ["card", "klarna", "amazon_pay"],
+                // Spara kortet på customern så det kan återanvändas / no-show-debiteras.
+                // Sätts per metod: Klarna stödjer inte off_session-sparande.
+                PaymentMethodOptions = new PaymentIntentPaymentMethodOptionsOptions
+                {
+                    Card = new PaymentIntentPaymentMethodOptionsCardOptions
+                    {
+                        SetupFutureUsage = "off_session",
+                    },
+                },
+            }, cancellationToken: ct);
+
+            return new PaymentIntentResult(intent.ClientSecret, intent.Id);
+        }
+
+        public async Task<PaymentIntentInfo?> GetPaymentIntentAsync(string paymentIntentId, CancellationToken ct)
+        {
+            try
+            {
+                // Expandera latest_charge: PI:ns status förblir "succeeded" efter refund,
+                // så återbetalning måste läsas från chargen.
+                var intent = await new PaymentIntentService(_client).GetAsync(paymentIntentId,
+                    new PaymentIntentGetOptions { Expand = ["latest_charge"] }, cancellationToken: ct);
+                var refunded = intent.LatestCharge is { } charge
+                    && (charge.Refunded || charge.AmountRefunded > 0);
+                return new PaymentIntentInfo(intent.Status, intent.AmountReceived, refunded,
+                    intent.Metadata ?? new Dictionary<string, string>());
+            }
+            catch (StripeException ex)
+            {
+                _logger.LogWarning(ex, "Could not fetch payment intent {PaymentIntentId}", paymentIntentId);
+                return null;
+            }
+        }
+
+        public async Task<StripeRefundResult> RefundAsync(
+            string paymentIntentId, long? amountMinorUnit, string idempotencyKey, CancellationToken ct)
+        {
+            try
+            {
+                var options = new RefundCreateOptions { PaymentIntent = paymentIntentId };
+                if (amountMinorUnit.HasValue) options.Amount = amountMinorUnit.Value;
+
+                await new RefundService(_client).CreateAsync(
+                    options, new RequestOptions { IdempotencyKey = idempotencyKey }, ct);
+                return new StripeRefundResult(true, null);
+            }
+            catch (StripeException ex)
+            {
+                _logger.LogWarning(ex, "Refund failed for payment intent {PaymentIntentId}", paymentIntentId);
+                return new StripeRefundResult(false, ex.StripeError?.Message ?? "Återbetalningen misslyckades.");
+            }
+        }
+
+        public async Task<CardDetails?> GetCardDetailsAsync(string paymentMethodId, CancellationToken ct)
+        {
+            try
+            {
+                var service = new PaymentMethodService(_client);
+                var pm = await service.GetAsync(paymentMethodId, cancellationToken: ct);
+                return pm.Card == null ? null : new CardDetails(pm.Card.Brand, pm.Card.Last4);
+            }
+            catch (StripeException ex)
+            {
+                _logger.LogWarning(ex, "Could not fetch card details for payment method {PaymentMethodId}", paymentMethodId);
+                return null;
+            }
+        }
+
+        public async Task<StripeChargeResult> ChargeOffSessionAsync(
+            string customerId, string paymentMethodId, long amountMinorUnit, string currency,
+            string description, IDictionary<string, string>? metadata, string idempotencyKey, CancellationToken ct)
+        {
+            try
+            {
+                var service = new PaymentIntentService(_client);
+                var intent = await service.CreateAsync(new PaymentIntentCreateOptions
+                {
+                    Amount = amountMinorUnit,
+                    Currency = currency,
+                    Customer = customerId,
+                    PaymentMethod = paymentMethodId,
+                    Confirm = true,
+                    OffSession = true, // kunden är inte närvarande — Stripe hoppar 3DS där det går
+                    Description = description,
+                    Metadata = metadata == null ? null : new Dictionary<string, string>(metadata),
+                }, new RequestOptions { IdempotencyKey = idempotencyKey }, ct);
+
+                var succeeded = intent.Status == "succeeded";
+                return new StripeChargeResult(succeeded, intent.Id, intent.Status,
+                    succeeded ? null : $"Betalningen kunde inte slutföras (status: {intent.Status}).");
+            }
+            catch (StripeException ex)
+            {
+                // Vanligast: kortet nekades eller kräver 3DS som inte kan göras off-session.
+                _logger.LogWarning(ex, "Off-session charge failed for customer {CustomerId}", customerId);
+                return new StripeChargeResult(false, ex.StripeError?.PaymentIntent?.Id, "failed",
+                    ex.StripeError?.Message ?? "Kortet kunde inte debiteras.");
+            }
+        }
+
+        public StripeWebhookResult? ParseWebhook(string json, string signatureHeader)
+        {
+            try
+            {
+                // throwOnApiVersionMismatch: false → webhooken avvisas inte om Stripe-kontots
+                // API-version skiljer sig från SDK:ns (annars kan riktiga events tyst felas).
+                var stripeEvent = EventUtility.ConstructEvent(
+                    json, signatureHeader, _webhookSecret, throwOnApiVersionMismatch: false);
+
+                string? bookingId = null;
+                string? paymentIntentId = null;
+                if (stripeEvent.Data.Object is PaymentIntent pi)
+                {
+                    paymentIntentId = pi.Id;
+                    pi.Metadata?.TryGetValue("bookingId", out bookingId);
+                }
+
+                return new StripeWebhookResult(stripeEvent.Type, paymentIntentId, bookingId, null);
+            }
+            catch (StripeException ex)
+            {
+                _logger.LogWarning(ex, "Rejected Stripe webhook with invalid signature");
+                return null;
+            }
+        }
+    }
+}

--- a/Test-Layer/BookingTests/CancelBookingCommandHandlerTests.cs
+++ b/Test-Layer/BookingTests/CancelBookingCommandHandlerTests.cs
@@ -1,4 +1,5 @@
 using Application_Layer.Commands.BookingCommands.CancelBooking;
+using Application_Layer.DTOs;
 using Application_Layer.Interfaces;
 using Domain_Layer.Common;
 using Domain_Layer.Models;
@@ -14,6 +15,7 @@ public class CancelBookingCommandHandlerTests
     private IServiceRepository _serviceRepository = null!;
     private IMediator _mediator = null!;
     private INotificationService _notificationService = null!;
+    private IStripePaymentService _stripe = null!;
     private CancelBookingCommandHandler _handler = null!;
 
     [SetUp]
@@ -23,8 +25,9 @@ public class CancelBookingCommandHandlerTests
         _serviceRepository = A.Fake<IServiceRepository>();
         _mediator = A.Fake<IMediator>();
         _notificationService = A.Fake<INotificationService>();
+        _stripe = A.Fake<IStripePaymentService>();
         _handler = new CancelBookingCommandHandler(
-            _bookingRepository, _serviceRepository, _mediator, _notificationService);
+            _bookingRepository, _serviceRepository, _mediator, _notificationService, _stripe);
     }
 
     private static BookingModel FutureBooking(string userId = "user-1") => new()
@@ -127,6 +130,81 @@ public class CancelBookingCommandHandlerTests
         {
             Assert.That(result.Successful, Is.False);
             Assert.That(booking.Status, Is.EqualTo(BookingStatus.Active));
+        });
+        A.CallTo(() => _bookingRepository.UpdateAsync(A<BookingModel>._)).MustNotHaveHappened();
+    }
+
+    private static BookingModel PaidBooking(double hoursUntilStart) => new()
+    {
+        Id = Guid.NewGuid(),
+        UserId = "user-1",
+        ServiceId = Guid.NewGuid(),
+        StartTime = SwedishTime.Now.AddHours(hoursUntilStart),
+        EndTime = SwedishTime.Now.AddHours(hoursUntilStart).AddMinutes(30),
+        Status = BookingStatus.Active,
+        PaymentStatus = PaymentStatus.PaidInFull,
+        AmountPaid = 2000m,
+        StripePaymentIntentId = "pi_1",
+    };
+
+    [Test]
+    public async Task Handle_WhenPaidOnlineAndMoreThan24hBefore_RefundsAndMarksRefunded()
+    {
+        var booking = PaidBooking(hoursUntilStart: 48);
+        A.CallTo(() => _stripe.IsConfigured).Returns(true);
+        A.CallTo(() => _bookingRepository.GetByIdAsync(booking.Id)).Returns(booking);
+        A.CallTo(() => _stripe.RefundAsync("pi_1", A<long?>._, A<string>._, A<CancellationToken>._))
+            .Returns(new StripeRefundResult(true, null));
+
+        var result = await _handler.Handle(
+            new CancelBookingCommand(booking.Id, booking.UserId, false), CancellationToken.None);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.Successful, Is.True);
+            Assert.That(booking.PaymentStatus, Is.EqualTo(PaymentStatus.Refunded));
+            Assert.That(booking.Status, Is.EqualTo(BookingStatus.Cancelled));
+        });
+        A.CallTo(() => _stripe.RefundAsync("pi_1", A<long?>._, A<string>._, A<CancellationToken>._))
+            .MustHaveHappenedOnceExactly();
+    }
+
+    [Test]
+    public async Task Handle_WhenPaidOnlineWithin24h_CancelsWithoutRefund()
+    {
+        var booking = PaidBooking(hoursUntilStart: 2);
+        A.CallTo(() => _stripe.IsConfigured).Returns(true);
+        A.CallTo(() => _bookingRepository.GetByIdAsync(booking.Id)).Returns(booking);
+
+        var result = await _handler.Handle(
+            new CancelBookingCommand(booking.Id, booking.UserId, false), CancellationToken.None);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.Successful, Is.True);
+            Assert.That(booking.Status, Is.EqualTo(BookingStatus.Cancelled));
+            Assert.That(booking.PaymentStatus, Is.EqualTo(PaymentStatus.PaidInFull), "pengarna behålls som sen-avboknings-avgift");
+        });
+        A.CallTo(() => _stripe.RefundAsync(A<string>._, A<long?>._, A<string>._, A<CancellationToken>._))
+            .MustNotHaveHappened();
+    }
+
+    [Test]
+    public async Task Handle_WhenRefundFails_BlocksCancellation()
+    {
+        var booking = PaidBooking(hoursUntilStart: 48);
+        A.CallTo(() => _stripe.IsConfigured).Returns(true);
+        A.CallTo(() => _bookingRepository.GetByIdAsync(booking.Id)).Returns(booking);
+        A.CallTo(() => _stripe.RefundAsync("pi_1", A<long?>._, A<string>._, A<CancellationToken>._))
+            .Returns(new StripeRefundResult(false, "Stripe nere."));
+
+        var result = await _handler.Handle(
+            new CancelBookingCommand(booking.Id, booking.UserId, false), CancellationToken.None);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.Successful, Is.False);
+            Assert.That(booking.Status, Is.EqualTo(BookingStatus.Active), "avbokning blockeras om återbetalning misslyckas");
         });
         A.CallTo(() => _bookingRepository.UpdateAsync(A<BookingModel>._)).MustNotHaveHappened();
     }

--- a/Test-Layer/BookingTests/CreateBookingCommandHandlerStripeTests.cs
+++ b/Test-Layer/BookingTests/CreateBookingCommandHandlerStripeTests.cs
@@ -1,0 +1,263 @@
+using Application_Layer.Commands.BookingCommands.CreateBooking;
+using Application_Layer.DTOs;
+using Application_Layer.Interfaces;
+using Application_Layer.Mapping;
+using Domain_Layer.Common;
+using Domain_Layer.Models;
+using FakeItEasy;
+using MediatR;
+
+namespace Test_Layer.BookingTests;
+
+/// <summary>Kort-på-fil-beteendet i bokningsskapandet (Stripe-vakt + kortlagring).</summary>
+[TestFixture]
+public class CreateBookingCommandHandlerStripeTests
+{
+    private IBookingRepository _bookingRepository = null!;
+    private IApplicationMapper _mapper = null!;
+    private IServiceRepository _serviceRepository = null!;
+    private IMediator _mediator = null!;
+    private INotificationService _notificationService = null!;
+    private IConversationRepository _conversationRepository = null!;
+    private IUserRepository _userRepository = null!;
+    private IStripePaymentService _stripe = null!;
+    private CreateBookingCommandHandler _handler = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _bookingRepository = A.Fake<IBookingRepository>();
+        _mapper = A.Fake<IApplicationMapper>();
+        _serviceRepository = A.Fake<IServiceRepository>();
+        _mediator = A.Fake<IMediator>();
+        _notificationService = A.Fake<INotificationService>();
+        _conversationRepository = A.Fake<IConversationRepository>();
+        _userRepository = A.Fake<IUserRepository>();
+        _stripe = A.Fake<IStripePaymentService>();
+
+        _handler = new CreateBookingCommandHandler(
+            _bookingRepository, _mapper, _serviceRepository, _mediator,
+            _notificationService, _conversationRepository, _userRepository, _stripe);
+
+        // Standard: en giltig tjänst och en mappad bokning utan tilldelad personal
+        // (så ingen konversation skapas), och konfliktfri insättning.
+        A.CallTo(() => _serviceRepository.GetServiceByIdAsync(A<Guid>._))
+            .Returns(new ServiceModel { Name = "Botox Panna", Price = 2000m });
+        A.CallTo(() => _mapper.ToBookingModel(A<CreateBookingDTO>._))
+            .ReturnsLazily(() => new BookingModel { UserId = "user-1" });
+        A.CallTo(() => _bookingRepository.TryAddIfNoConflictAsync(A<BookingModel>._)).Returns(true);
+    }
+
+    private static CreateBookingCommand Command(string? paymentMethodId) => new(new CreateBookingDTO
+    {
+        UserId = "user-1",
+        ServiceId = Guid.NewGuid(),
+        StartTime = DateTime.Now.AddDays(5),
+        EndTime = DateTime.Now.AddDays(5).AddMinutes(30),
+        EmployeeId = "", // ingen personal → ingen konversation
+        PaymentMethodId = paymentMethodId,
+    });
+
+    [Test]
+    public async Task Handle_WhenStripeConfiguredAndNoCard_FailsWithoutCreatingBooking()
+    {
+        A.CallTo(() => _stripe.IsConfigured).Returns(true);
+
+        var result = await _handler.Handle(Command(paymentMethodId: null), CancellationToken.None);
+
+        Assert.That(result.Successful, Is.False);
+        A.CallTo(() => _bookingRepository.TryAddIfNoConflictAsync(A<BookingModel>._)).MustNotHaveHappened();
+    }
+
+    [Test]
+    public async Task Handle_WhenStripeConfiguredWithCard_StoresPaymentMethodAndCardDetails()
+    {
+        A.CallTo(() => _stripe.IsConfigured).Returns(true);
+        A.CallTo(() => _stripe.GetCardDetailsAsync("pm_123", A<CancellationToken>._))
+            .Returns(new CardDetails("visa", "4242"));
+
+        BookingModel? saved = null;
+        A.CallTo(() => _bookingRepository.TryAddIfNoConflictAsync(A<BookingModel>._))
+            .Invokes((BookingModel b) => saved = b)
+            .Returns(true);
+
+        var result = await _handler.Handle(Command("pm_123"), CancellationToken.None);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.Successful, Is.True);
+            Assert.That(saved!.StripePaymentMethodId, Is.EqualTo("pm_123"));
+            Assert.That(saved.CardBrand, Is.EqualTo("visa"));
+            Assert.That(saved.CardLast4, Is.EqualTo("4242"));
+        });
+    }
+
+    [Test]
+    public async Task Handle_WhenStripeNotConfigured_CreatesBookingWithoutCard()
+    {
+        A.CallTo(() => _stripe.IsConfigured).Returns(false);
+
+        BookingModel? saved = null;
+        A.CallTo(() => _bookingRepository.TryAddIfNoConflictAsync(A<BookingModel>._))
+            .Invokes((BookingModel b) => saved = b)
+            .Returns(true);
+
+        var result = await _handler.Handle(Command(paymentMethodId: null), CancellationToken.None);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.Successful, Is.True);
+            Assert.That(saved!.StripePaymentMethodId, Is.Null);
+        });
+        A.CallTo(() => _stripe.GetCardDetailsAsync(A<string>._, A<CancellationToken>._)).MustNotHaveHappened();
+    }
+
+    private static CreateBookingCommand OnlineCommand(string paymentIntentId) => new(new CreateBookingDTO
+    {
+        UserId = "user-1",
+        ServiceId = Guid.NewGuid(),
+        StartTime = DateTime.Now.AddDays(5),
+        EndTime = DateTime.Now.AddDays(5).AddMinutes(30),
+        EmployeeId = "",
+        PaymentIntentId = paymentIntentId,
+    });
+
+    [Test]
+    public async Task Handle_WhenPaidInFullOnline_StoresPaidInFullAndAmount()
+    {
+        // Service = 2000 kr → full betalning = 200000 öre.
+        A.CallTo(() => _stripe.IsConfigured).Returns(true);
+        A.CallTo(() => _stripe.GetPaymentIntentAsync("pi_1", A<CancellationToken>._))
+            .Returns(new PaymentIntentInfo("succeeded", 200000, false, new Dictionary<string, string>()));
+
+        BookingModel? saved = null;
+        A.CallTo(() => _bookingRepository.TryAddIfNoConflictAsync(A<BookingModel>._))
+            .Invokes((BookingModel b) => saved = b).Returns(true);
+
+        var result = await _handler.Handle(OnlineCommand("pi_1"), CancellationToken.None);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.Successful, Is.True);
+            Assert.That(saved!.PaymentStatus, Is.EqualTo(PaymentStatus.PaidInFull));
+            Assert.That(saved.AmountPaid, Is.EqualTo(2000m));
+            Assert.That(saved.StripePaymentIntentId, Is.EqualTo("pi_1"));
+        });
+    }
+
+    [Test]
+    public async Task Handle_WhenPaymentNotSucceeded_FailsWithoutBooking()
+    {
+        A.CallTo(() => _stripe.IsConfigured).Returns(true);
+        A.CallTo(() => _stripe.GetPaymentIntentAsync("pi_3", A<CancellationToken>._))
+            .Returns(new PaymentIntentInfo("requires_payment_method", 0, false, new Dictionary<string, string>()));
+
+        var result = await _handler.Handle(OnlineCommand("pi_3"), CancellationToken.None);
+
+        Assert.That(result.Successful, Is.False);
+        A.CallTo(() => _bookingRepository.TryAddIfNoConflictAsync(A<BookingModel>._)).MustNotHaveHappened();
+    }
+
+    [Test]
+    public async Task Handle_WhenPaymentIntentAlreadyUsed_FailsWithoutBooking()
+    {
+        // Skydd: samma betalning får inte ge två bokningar (t.ex. omkört Klarna-returflöde).
+        A.CallTo(() => _stripe.IsConfigured).Returns(true);
+        A.CallTo(() => _bookingRepository.ExistsByPaymentIntentIdAsync("pi_used")).Returns(true);
+
+        var result = await _handler.Handle(OnlineCommand("pi_used"), CancellationToken.None);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.Successful, Is.False);
+            Assert.That(result.FailureType, Is.EqualTo(OperationFailureType.Conflict));
+        });
+        A.CallTo(() => _stripe.GetPaymentIntentAsync(A<string>._, A<CancellationToken>._)).MustNotHaveHappened();
+        A.CallTo(() => _bookingRepository.TryAddIfNoConflictAsync(A<BookingModel>._)).MustNotHaveHappened();
+    }
+
+    [Test]
+    public async Task Handle_WhenSlotTakenAfterOnlinePayment_RefundsAutomatically()
+    {
+        // Kunden betalade (t.ex. via Klarna-redirect) men tiden hann tas → auto-refund.
+        A.CallTo(() => _stripe.IsConfigured).Returns(true);
+        A.CallTo(() => _stripe.GetPaymentIntentAsync("pi_5", A<CancellationToken>._))
+            .Returns(new PaymentIntentInfo("succeeded", 200000, false, new Dictionary<string, string>()));
+        A.CallTo(() => _bookingRepository.TryAddIfNoConflictAsync(A<BookingModel>._)).Returns(false);
+        A.CallTo(() => _stripe.RefundAsync("pi_5", null, "conflict-refund-pi_5", A<CancellationToken>._))
+            .Returns(new StripeRefundResult(true, null));
+
+        var result = await _handler.Handle(OnlineCommand("pi_5"), CancellationToken.None);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.Successful, Is.False);
+            Assert.That(result.Error, Does.Contain("återbetalas"));
+        });
+        A.CallTo(() => _stripe.RefundAsync("pi_5", null, "conflict-refund-pi_5", A<CancellationToken>._))
+            .MustHaveHappenedOnceExactly();
+    }
+
+    [Test]
+    public async Task Handle_WhenPaymentRefunded_FailsWithoutBooking()
+    {
+        // Stripe låter status vara "succeeded" efter refund — flaggan måste stoppa bokning.
+        A.CallTo(() => _stripe.IsConfigured).Returns(true);
+        A.CallTo(() => _stripe.GetPaymentIntentAsync("pi_ref", A<CancellationToken>._))
+            .Returns(new PaymentIntentInfo("succeeded", 200000, true, new Dictionary<string, string>()));
+
+        var result = await _handler.Handle(OnlineCommand("pi_ref"), CancellationToken.None);
+
+        Assert.That(result.Successful, Is.False);
+        A.CallTo(() => _bookingRepository.TryAddIfNoConflictAsync(A<BookingModel>._)).MustNotHaveHappened();
+    }
+
+    [Test]
+    public async Task Handle_WhenConflictButSamePaymentAlreadyBooked_DoesNotRefund()
+    {
+        // Race: returflödet och webhooken tävlar om samma PI. Förloraren får slot-konflikt,
+        // men betalningen sitter redan på vinnarens bokning → INGEN refund (annars hade
+        // kunden fått både bokning och pengar tillbaka).
+        A.CallTo(() => _stripe.IsConfigured).Returns(true);
+        A.CallTo(() => _stripe.GetPaymentIntentAsync("pi_race", A<CancellationToken>._))
+            .Returns(new PaymentIntentInfo("succeeded", 200000, false, new Dictionary<string, string>()));
+        // Första exists-kollen (vakten) passerar, andra (efter konflikt) ser vinnarens bokning.
+        A.CallTo(() => _bookingRepository.ExistsByPaymentIntentIdAsync("pi_race"))
+            .ReturnsNextFromSequence(false, true);
+        A.CallTo(() => _bookingRepository.TryAddIfNoConflictAsync(A<BookingModel>._)).Returns(false);
+
+        var result = await _handler.Handle(OnlineCommand("pi_race"), CancellationToken.None);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.Successful, Is.False);
+            Assert.That(result.FailureType, Is.EqualTo(OperationFailureType.Conflict));
+        });
+        A.CallTo(() => _stripe.RefundAsync(A<string>._, A<long?>._, A<string>._, A<CancellationToken>._))
+            .MustNotHaveHappened();
+    }
+
+    [Test]
+    public async Task Handle_WhenPaidAmountMismatch_Fails()
+    {
+        // Betalade bara 500 kr men "full" borde vara 2000 → nekas (klienten kan inte manipulera beloppet).
+        A.CallTo(() => _stripe.IsConfigured).Returns(true);
+        A.CallTo(() => _stripe.GetPaymentIntentAsync("pi_4", A<CancellationToken>._))
+            .Returns(new PaymentIntentInfo("succeeded", 50000, false, new Dictionary<string, string>()));
+
+        A.CallTo(() => _stripe.RefundAsync("pi_4", null, "amount-mismatch-refund-pi_4", A<CancellationToken>._))
+            .Returns(new StripeRefundResult(true, null));
+
+        var result = await _handler.Handle(OnlineCommand("pi_4"), CancellationToken.None);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.Successful, Is.False);
+            Assert.That(result.Error, Does.Contain("återbetalas"));
+        });
+        A.CallTo(() => _bookingRepository.TryAddIfNoConflictAsync(A<BookingModel>._)).MustNotHaveHappened();
+        // Pengar utan bokning får aldrig behållas → beloppsmiss återbetalas automatiskt.
+        A.CallTo(() => _stripe.RefundAsync("pi_4", null, "amount-mismatch-refund-pi_4", A<CancellationToken>._))
+            .MustHaveHappenedOnceExactly();
+    }
+}

--- a/Test-Layer/BookingTests/GetBookingsReportQueryHandlerTests.cs
+++ b/Test-Layer/BookingTests/GetBookingsReportQueryHandlerTests.cs
@@ -88,6 +88,58 @@ public class GetBookingsReportQueryHandlerTests
     }
 
     [Test]
+    public async Task Handle_ExcludesNoShowFromTotals_ButCountsAndListsThem()
+    {
+        var day = new DateTime(2026, 7, 1);
+        var noShow = Booking("Botox Panna", 2000m, day.AddHours(9));
+        noShow.Status = BookingStatus.NoShow;
+
+        A.CallTo(() => _bookingRepository.GetByDateRangeAsync(A<DateTime>._, A<DateTime>._, A<bool>._))
+            .Returns(
+            [
+                Booking("Botox Panna", 2000m, day.AddHours(10)),
+                Booking("Läppfillers 1 ml", 2500m, day.AddHours(14)),
+                noShow,
+            ]);
+
+        var report = await _handler.Handle(
+            new GetBookingsReportQuery(day, day), CancellationToken.None);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(report.TotalBookings, Is.EqualTo(2), "uteblivna räknas inte som aktiva");
+            Assert.That(report.TotalRevenue, Is.EqualTo(4500m),
+                "uteblivna ger ingen behandlingsintäkt (no-show-avgiften bokförs hos Stripe)");
+            Assert.That(report.NoShowBookings, Is.EqualTo(1));
+            Assert.That(report.CancelledBookings, Is.EqualTo(0));
+            Assert.That(report.Rows, Has.Count.EqualTo(3), "alla rader listas, även uteblivna");
+            Assert.That(report.Rows.Count(r => r.IsNoShow), Is.EqualTo(1));
+            Assert.That(report.PerService.Sum(l => l.Count), Is.EqualTo(2),
+                "per-behandling räknar bara aktiva");
+        });
+    }
+
+    [Test]
+    public async Task Csv_ShowsNoShowStatusAndCount()
+    {
+        var day = new DateTime(2026, 7, 1);
+        var noShow = Booking("Botox Panna", 2000m, day.AddHours(9));
+        noShow.Status = BookingStatus.NoShow;
+
+        A.CallTo(() => _bookingRepository.GetByDateRangeAsync(A<DateTime>._, A<DateTime>._, A<bool>._))
+            .Returns([Booking("Läppfillers 1 ml", 2500m, day.AddHours(10)), noShow]);
+
+        var report = await _handler.Handle(new GetBookingsReportQuery(day, day), CancellationToken.None);
+        var csv = BookingsReportCsvBuilder.Build(report);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(csv, Does.Contain(";Utebliven"), "utebliven rad får status Utebliven");
+            Assert.That(csv, Does.Contain("Antal uteblivna;1"));
+        });
+    }
+
+    [Test]
     public async Task Handle_RequestsCancelledFromRepository_WithInclusiveEndDate()
     {
         var from = new DateTime(2026, 7, 1);
@@ -146,7 +198,7 @@ public class GetBookingsReportQueryHandlerTests
             Assert.That(csv, Does.Contain("1999,5"), "svensk decimalkomma");
             Assert.That(csv, Does.Contain(";Aktiv"), "aktiv rad får status Aktiv");
             Assert.That(csv, Does.Contain(";Avbokad"), "avbokad rad får status Avbokad");
-            Assert.That(csv, Does.Contain("Total omsättning (kr);1999,5"));
+            Assert.That(csv, Does.Contain("Bokat värde (kr);1999,5"));
             Assert.That(csv, Does.Contain("Antal avbokningar;1"));
         });
     }

--- a/Test-Layer/BookingTests/MarkBookingNoShowCommandHandlerTests.cs
+++ b/Test-Layer/BookingTests/MarkBookingNoShowCommandHandlerTests.cs
@@ -1,0 +1,203 @@
+using Application_Layer.Commands.BookingCommands.MarkBookingNoShow;
+using Application_Layer.DTOs;
+using Application_Layer.Interfaces;
+using Domain_Layer.Common;
+using Domain_Layer.Models;
+using FakeItEasy;
+using MediatR;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Test_Layer.BookingTests;
+
+[TestFixture]
+public class MarkBookingNoShowCommandHandlerTests
+{
+    private IBookingRepository _bookingRepository = null!;
+    private IUserRepository _userRepository = null!;
+    private IServiceRepository _serviceRepository = null!;
+    private IStripePaymentService _stripe = null!;
+    private IMediator _mediator = null!;
+    private INotificationService _notificationService = null!;
+    private MarkBookingNoShowCommandHandler _handler = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _bookingRepository = A.Fake<IBookingRepository>();
+        _userRepository = A.Fake<IUserRepository>();
+        _serviceRepository = A.Fake<IServiceRepository>();
+        _stripe = A.Fake<IStripePaymentService>();
+        _mediator = A.Fake<IMediator>();
+        _notificationService = A.Fake<INotificationService>();
+
+        var config = new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            ["Stripe:NoShowFeeAmount"] = "200",
+            ["Stripe:Currency"] = "sek",
+        }).Build();
+
+        _handler = new MarkBookingNoShowCommandHandler(
+            _bookingRepository, _userRepository, _serviceRepository, _stripe,
+            _mediator, _notificationService, config,
+            NullLogger<MarkBookingNoShowCommandHandler>.Instance);
+    }
+
+    private static BookingModel PastBookingWithCard() => new()
+    {
+        Id = Guid.NewGuid(),
+        UserId = "user-1",
+        ServiceId = Guid.NewGuid(),
+        StartTime = SwedishTime.Now.AddHours(-2),
+        EndTime = SwedishTime.Now.AddHours(-1),
+        Status = BookingStatus.Active,
+        StripePaymentMethodId = "pm_123",
+    };
+
+    private void StripeConfigured(bool configured) =>
+        A.CallTo(() => _stripe.IsConfigured).Returns(configured);
+
+    [Test]
+    public async Task Handle_WhenConfigured_ChargesCardAndMarksNoShow()
+    {
+        var booking = PastBookingWithCard();
+        StripeConfigured(true);
+        A.CallTo(() => _bookingRepository.GetByIdAsync(booking.Id)).Returns(booking);
+        A.CallTo(() => _userRepository.FindByIdAsync("user-1"))
+            .Returns(new UserModel { Id = "user-1", StripeCustomerId = "cus_123" });
+        A.CallTo(() => _stripe.ChargeOffSessionAsync(
+                "cus_123", "pm_123", 20000, "sek", A<string>._, A<IDictionary<string, string>>._, A<string>._, A<CancellationToken>._))
+            .Returns(new StripeChargeResult(true, "pi_1", "succeeded", null));
+
+        var result = await _handler.Handle(new MarkBookingNoShowCommand(booking.Id), CancellationToken.None);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.Successful, Is.True);
+            Assert.That(booking.Status, Is.EqualTo(BookingStatus.NoShow));
+            Assert.That(booking.NoShowFeeChargedAt, Is.Not.Null);
+        });
+        A.CallTo(() => _stripe.ChargeOffSessionAsync(
+                "cus_123", "pm_123", 20000, "sek", A<string>._, A<IDictionary<string, string>>._, A<string>._, A<CancellationToken>._))
+            .MustHaveHappenedOnceExactly();
+        A.CallTo(() => _bookingRepository.UpdateAsync(booking)).MustHaveHappenedOnceExactly();
+        A.CallTo(() => _notificationService.SendBookingNotificationAsync(
+                "user-1", A<string>._, A<string>._, NotificationType.NoShowFeeCharged, booking.Id))
+            .MustHaveHappenedOnceExactly();
+    }
+
+    [Test]
+    public async Task Handle_WhenBookingIsInFuture_FailsWithoutCharging()
+    {
+        var booking = PastBookingWithCard();
+        booking.StartTime = SwedishTime.Now.AddDays(1);
+        StripeConfigured(true);
+        A.CallTo(() => _bookingRepository.GetByIdAsync(booking.Id)).Returns(booking);
+
+        var result = await _handler.Handle(new MarkBookingNoShowCommand(booking.Id), CancellationToken.None);
+
+        Assert.That(result.Successful, Is.False);
+        A.CallTo(() => _stripe.ChargeOffSessionAsync(
+                A<string>._, A<string>._, A<long>._, A<string>._, A<string>._, A<IDictionary<string, string>>._, A<string>._, A<CancellationToken>._))
+            .MustNotHaveHappened();
+        A.CallTo(() => _bookingRepository.UpdateAsync(A<BookingModel>._)).MustNotHaveHappened();
+    }
+
+    [Test]
+    public async Task Handle_WhenBookingNotFound_ReturnsNotFound()
+    {
+        var id = Guid.NewGuid();
+        A.CallTo(() => _bookingRepository.GetByIdAsync(id)).Returns((BookingModel?)null);
+
+        var result = await _handler.Handle(new MarkBookingNoShowCommand(id), CancellationToken.None);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.Successful, Is.False);
+            Assert.That(result.FailureType, Is.EqualTo(OperationFailureType.NotFound));
+        });
+    }
+
+    [Test]
+    public async Task Handle_WhenChargeFails_DoesNotMarkNoShow()
+    {
+        var booking = PastBookingWithCard();
+        StripeConfigured(true);
+        A.CallTo(() => _bookingRepository.GetByIdAsync(booking.Id)).Returns(booking);
+        A.CallTo(() => _userRepository.FindByIdAsync("user-1"))
+            .Returns(new UserModel { Id = "user-1", StripeCustomerId = "cus_123" });
+        A.CallTo(() => _stripe.ChargeOffSessionAsync(
+                A<string>._, A<string>._, A<long>._, A<string>._, A<string>._, A<IDictionary<string, string>>._, A<string>._, A<CancellationToken>._))
+            .Returns(new StripeChargeResult(false, null, "failed", "Kortet nekades."));
+
+        var result = await _handler.Handle(new MarkBookingNoShowCommand(booking.Id), CancellationToken.None);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.Successful, Is.False);
+            Assert.That(booking.Status, Is.EqualTo(BookingStatus.Active), "status ska inte ändras om debiteringen misslyckas");
+        });
+        A.CallTo(() => _bookingRepository.UpdateAsync(A<BookingModel>._)).MustNotHaveHappened();
+    }
+
+    [Test]
+    public async Task Handle_WhenStripeNotConfigured_MarksNoShowWithoutCharge()
+    {
+        var booking = PastBookingWithCard();
+        StripeConfigured(false);
+        A.CallTo(() => _bookingRepository.GetByIdAsync(booking.Id)).Returns(booking);
+
+        var result = await _handler.Handle(new MarkBookingNoShowCommand(booking.Id), CancellationToken.None);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.Successful, Is.True);
+            Assert.That(booking.Status, Is.EqualTo(BookingStatus.NoShow));
+            Assert.That(booking.NoShowFeeChargedAt, Is.Null);
+        });
+        A.CallTo(() => _stripe.ChargeOffSessionAsync(
+                A<string>._, A<string>._, A<long>._, A<string>._, A<string>._, A<IDictionary<string, string>>._, A<string>._, A<CancellationToken>._))
+            .MustNotHaveHappened();
+        A.CallTo(() => _bookingRepository.UpdateAsync(booking)).MustHaveHappenedOnceExactly();
+    }
+
+    [Test]
+    public async Task Handle_WhenConfiguredButBookingHasNoCard_Fails()
+    {
+        var booking = PastBookingWithCard();
+        booking.StripePaymentMethodId = null;
+        StripeConfigured(true);
+        A.CallTo(() => _bookingRepository.GetByIdAsync(booking.Id)).Returns(booking);
+        A.CallTo(() => _userRepository.FindByIdAsync("user-1"))
+            .Returns(new UserModel { Id = "user-1", StripeCustomerId = "cus_123" });
+
+        var result = await _handler.Handle(new MarkBookingNoShowCommand(booking.Id), CancellationToken.None);
+
+        Assert.That(result.Successful, Is.False);
+        A.CallTo(() => _stripe.ChargeOffSessionAsync(
+                A<string>._, A<string>._, A<long>._, A<string>._, A<string>._, A<IDictionary<string, string>>._, A<string>._, A<CancellationToken>._))
+            .MustNotHaveHappened();
+    }
+
+    [Test]
+    public async Task Handle_WhenPrepaidOnline_MarksNoShowWithoutChargingCard()
+    {
+        // Kunden har redan betalat online → ingen kortdebitering, bara markera utebliven.
+        var booking = PastBookingWithCard();
+        booking.PaymentStatus = PaymentStatus.PaidInFull;
+        booking.StripePaymentMethodId = null;
+        StripeConfigured(true);
+        A.CallTo(() => _bookingRepository.GetByIdAsync(booking.Id)).Returns(booking);
+
+        var result = await _handler.Handle(new MarkBookingNoShowCommand(booking.Id), CancellationToken.None);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.Successful, Is.True);
+            Assert.That(booking.Status, Is.EqualTo(BookingStatus.NoShow));
+        });
+        A.CallTo(() => _stripe.ChargeOffSessionAsync(
+                A<string>._, A<string>._, A<long>._, A<string>._, A<string>._, A<IDictionary<string, string>>._, A<string>._, A<CancellationToken>._))
+            .MustNotHaveHappened();
+    }
+}

--- a/Test-Layer/BookingTests/ReconcilePaidBookingCommandHandlerTests.cs
+++ b/Test-Layer/BookingTests/ReconcilePaidBookingCommandHandlerTests.cs
@@ -1,0 +1,180 @@
+using Application_Layer.Commands.BookingCommands.CreateBooking;
+using Application_Layer.Commands.BookingCommands.ReconcilePaidBooking;
+using Application_Layer.DTOs;
+using Application_Layer.Interfaces;
+using Domain_Layer.Common;
+using Domain_Layer.Models;
+using FakeItEasy;
+using MediatR;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Test_Layer.BookingTests;
+
+/// <summary>Avstämning av en genomförd onlinebetalning till en bokning (retur/webhook).</summary>
+[TestFixture]
+public class ReconcilePaidBookingCommandHandlerTests
+{
+    private IStripePaymentService _stripe = null!;
+    private IBookingRepository _bookingRepository = null!;
+    private IMediator _mediator = null!;
+    private ReconcilePaidBookingCommandHandler _handler = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _stripe = A.Fake<IStripePaymentService>();
+        _bookingRepository = A.Fake<IBookingRepository>();
+        _mediator = A.Fake<IMediator>();
+        A.CallTo(() => _stripe.IsConfigured).Returns(true);
+        _handler = new ReconcilePaidBookingCommandHandler(
+            _stripe, _bookingRepository, _mediator,
+            NullLogger<ReconcilePaidBookingCommandHandler>.Instance);
+    }
+
+    private static Dictionary<string, string> ValidMeta(DateTime? start = null) => new()
+    {
+        ["userId"] = "user-1",
+        ["serviceId"] = Guid.NewGuid().ToString(),
+        ["employeeId"] = Guid.NewGuid().ToString(),
+        ["startTime"] = (start ?? DateTime.Now.AddDays(3)).ToString("o"),
+        ["endTime"] = (start ?? DateTime.Now.AddDays(3)).AddMinutes(30).ToString("o"),
+    };
+
+    [Test]
+    public async Task Handle_WhenSucceededWithMetadata_SendsCreateBooking()
+    {
+        A.CallTo(() => _stripe.GetPaymentIntentAsync("pi_1", A<CancellationToken>._))
+            .Returns(new PaymentIntentInfo("succeeded", 200000, false, ValidMeta()));
+        A.CallTo(() => _mediator.Send(A<CreateBookingCommand>._, A<CancellationToken>._))
+            .Returns(OperationResult<BookingModel>.Success(new BookingModel { UserId = "user-1" }));
+
+        var result = await _handler.Handle(new ReconcilePaidBookingCommand("pi_1", "user-1"), CancellationToken.None);
+
+        Assert.That(result.Successful, Is.True);
+        A.CallTo(() => _mediator.Send(
+                A<CreateBookingCommand>.That.Matches(c => c.Booking.PaymentIntentId == "pi_1"
+                    && c.Booking.UserId == "user-1"),
+                A<CancellationToken>._))
+            .MustHaveHappenedOnceExactly();
+    }
+
+    [Test]
+    public async Task Handle_WhenPaymentAlreadyLinked_ReturnsConflictWithoutStripeCall()
+    {
+        // Idempotens: webhooken och returflödet kan båda stämma av samma betalning.
+        A.CallTo(() => _bookingRepository.ExistsByPaymentIntentIdAsync("pi_dup")).Returns(true);
+
+        var result = await _handler.Handle(new ReconcilePaidBookingCommand("pi_dup", "user-1"), CancellationToken.None);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.Successful, Is.False);
+            Assert.That(result.FailureType, Is.EqualTo(OperationFailureType.Conflict));
+        });
+        A.CallTo(() => _stripe.GetPaymentIntentAsync(A<string>._, A<CancellationToken>._)).MustNotHaveHappened();
+        A.CallTo(() => _mediator.Send(A<CreateBookingCommand>._, A<CancellationToken>._)).MustNotHaveHappened();
+    }
+
+    [Test]
+    public async Task Handle_WhenCallerDoesNotOwnPayment_ReturnsForbidden()
+    {
+        // Användare A får inte slutföra användare B:s betalning.
+        A.CallTo(() => _stripe.GetPaymentIntentAsync("pi_1", A<CancellationToken>._))
+            .Returns(new PaymentIntentInfo("succeeded", 200000, false, ValidMeta()));
+
+        var result = await _handler.Handle(new ReconcilePaidBookingCommand("pi_1", "user-EVIL"), CancellationToken.None);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.Successful, Is.False);
+            Assert.That(result.FailureType, Is.EqualTo(OperationFailureType.Forbidden));
+        });
+        A.CallTo(() => _mediator.Send(A<CreateBookingCommand>._, A<CancellationToken>._)).MustNotHaveHappened();
+    }
+
+    [Test]
+    public async Task Handle_WhenWebhookWithoutUser_SkipsOwnershipCheck()
+    {
+        // Webhooken (RequestingUserId=null) auktoriseras av Stripe-signaturen.
+        A.CallTo(() => _stripe.GetPaymentIntentAsync("pi_1", A<CancellationToken>._))
+            .Returns(new PaymentIntentInfo("succeeded", 200000, false, ValidMeta()));
+        A.CallTo(() => _mediator.Send(A<CreateBookingCommand>._, A<CancellationToken>._))
+            .Returns(OperationResult<BookingModel>.Success(new BookingModel { UserId = "user-1" }));
+
+        var result = await _handler.Handle(new ReconcilePaidBookingCommand("pi_1", null), CancellationToken.None);
+
+        Assert.That(result.Successful, Is.True);
+    }
+
+    [Test]
+    public async Task Handle_WhenSlotAlreadyPassed_RefundsInsteadOfBooking()
+    {
+        // Sen omleverans av webhook: tiden har passerat → återbetala, boka inte.
+        A.CallTo(() => _stripe.GetPaymentIntentAsync("pi_late", A<CancellationToken>._))
+            .Returns(new PaymentIntentInfo("succeeded", 200000, false, ValidMeta(SwedishTime.Now.AddHours(-2))));
+        A.CallTo(() => _stripe.RefundAsync("pi_late", null, "reconcile-expired-refund-pi_late", A<CancellationToken>._))
+            .Returns(new StripeRefundResult(true, null));
+
+        var result = await _handler.Handle(new ReconcilePaidBookingCommand("pi_late", null), CancellationToken.None);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.Successful, Is.False);
+            Assert.That(result.Error, Does.Contain("återbetalas"));
+        });
+        A.CallTo(() => _stripe.RefundAsync("pi_late", null, "reconcile-expired-refund-pi_late", A<CancellationToken>._))
+            .MustHaveHappenedOnceExactly();
+        A.CallTo(() => _mediator.Send(A<CreateBookingCommand>._, A<CancellationToken>._)).MustNotHaveHappened();
+    }
+
+    [Test]
+    public async Task Handle_WhenPaymentRefunded_FailsWithoutBooking()
+    {
+        A.CallTo(() => _stripe.GetPaymentIntentAsync("pi_ref", A<CancellationToken>._))
+            .Returns(new PaymentIntentInfo("succeeded", 200000, true, ValidMeta()));
+
+        var result = await _handler.Handle(new ReconcilePaidBookingCommand("pi_ref", null), CancellationToken.None);
+
+        Assert.That(result.Successful, Is.False);
+        A.CallTo(() => _mediator.Send(A<CreateBookingCommand>._, A<CancellationToken>._)).MustNotHaveHappened();
+    }
+
+    [Test]
+    public async Task Handle_WhenNotSucceeded_FailsWithoutBooking()
+    {
+        A.CallTo(() => _stripe.GetPaymentIntentAsync("pi_2", A<CancellationToken>._))
+            .Returns(new PaymentIntentInfo("processing", 0, false, ValidMeta()));
+
+        var result = await _handler.Handle(new ReconcilePaidBookingCommand("pi_2", null), CancellationToken.None);
+
+        Assert.That(result.Successful, Is.False);
+        A.CallTo(() => _mediator.Send(A<CreateBookingCommand>._, A<CancellationToken>._)).MustNotHaveHappened();
+    }
+
+    [Test]
+    public async Task Handle_WhenMetadataMissing_FailsWithoutBooking()
+    {
+        A.CallTo(() => _stripe.GetPaymentIntentAsync("pi_3", A<CancellationToken>._))
+            .Returns(new PaymentIntentInfo("succeeded", 200000, false, new Dictionary<string, string>()));
+
+        var result = await _handler.Handle(new ReconcilePaidBookingCommand("pi_3", null), CancellationToken.None);
+
+        Assert.That(result.Successful, Is.False);
+        A.CallTo(() => _mediator.Send(A<CreateBookingCommand>._, A<CancellationToken>._)).MustNotHaveHappened();
+    }
+
+    [Test]
+    public async Task Handle_WhenPaymentIntentNotFound_ReturnsNotFound()
+    {
+        A.CallTo(() => _stripe.GetPaymentIntentAsync("pi_x", A<CancellationToken>._))
+            .Returns((PaymentIntentInfo?)null);
+
+        var result = await _handler.Handle(new ReconcilePaidBookingCommand("pi_x", null), CancellationToken.None);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.Successful, Is.False);
+            Assert.That(result.FailureType, Is.EqualTo(OperationFailureType.NotFound));
+        });
+    }
+}


### PR DESCRIPTION
…k reconciliation

- SetupIntent (kort-pa-fil) + no-show-avgift off-session med idempotency keys
- PaymentIntent (kort/Klarna/Amazon Pay) med serverside-verifiering av belopp och status; aterbetald betalning kan aldrig ateranvandas (latest_charge)
- Aterbetalning vid avbokning >24h fore; auto-refund vid slot-konflikt, beloppsmiss och for sent avstamd betalning
- Webhook-reconciliation ur PI-metadata (orphan-skydd nar kunden aldrig kommer tillbaka fran Klarna/Amazon Pay-redirect); idempotent via unikt filtrerat index pa StripePaymentIntentId
- Agarskapskontroll pa POST /bookings/from-payment
- Rapport: AmountCollected (inbetalt online) vs bokat varde; NoShow-status
- 132 tester grona; e2e 28/28 mot skarpt Stripe-testlage inkl. webhook-race